### PR TITLE
[codex] Add multiplayer save support and improve path detection

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -14,7 +14,12 @@
     "closeSession": "Close Session",
     "active": "Active",
     "sessionActive": "Session Active: {name}",
-    "openSave": "Open Save"
+    "openSave": "Open Save",
+    "singlePlayer": "Single Player",
+    "multiplayer": "Multiplayer",
+    "chooseCharacter": "Choose Character",
+    "chooseCharacterHint": "{save} contains multiple player characters. Pick the one to edit.",
+    "playerSlot": "Slot {slot}"
   },
   "fileBrowser": {
     "loadSave": "Load Save",

--- a/src-tauri/src/commands/paths.rs
+++ b/src-tauri/src/commands/paths.rs
@@ -96,6 +96,11 @@ fn build_path_config(paths: &crate::config::NWN2Paths) -> PathConfig {
     }
 }
 
+async fn sync_resource_manager_paths(state: &AppState, snapshot: crate::config::NWN2Paths) {
+    let mut resource_manager = state.resource_manager.write().await;
+    resource_manager.update_paths(snapshot).await;
+}
+
 #[tauri::command]
 #[instrument(name = "get_paths_config", skip(state))]
 pub async fn get_paths_config(state: State<'_, AppState>) -> CommandResult<PathConfig> {
@@ -111,25 +116,29 @@ pub async fn set_game_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Setting game folder to: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths.set_game_folder(&path).map_err(|e| {
-        if e.contains("does not exist") {
-            CommandError::NotFound {
-                item: format!("Path: {path}"),
+        paths.set_game_folder(&path).map_err(|e| {
+            if e.contains("does not exist") {
+                CommandError::NotFound {
+                    item: format!("Path: {path}"),
+                }
+            } else {
+                CommandError::OperationFailed {
+                    operation: "set_game_folder".to_string(),
+                    reason: e,
+                }
             }
-        } else {
-            CommandError::OperationFailed {
-                operation: "set_game_folder".to_string(),
-                reason: e,
-            }
-        }
-    })?;
+        })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("Game folder set to: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -140,25 +149,29 @@ pub async fn set_documents_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Setting documents folder to: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths.set_documents_folder(&path).map_err(|e| {
-        if e.contains("does not exist") {
-            CommandError::NotFound {
-                item: format!("Path: {path}"),
+        paths.set_documents_folder(&path).map_err(|e| {
+            if e.contains("does not exist") {
+                CommandError::NotFound {
+                    item: format!("Path: {path}"),
+                }
+            } else {
+                CommandError::OperationFailed {
+                    operation: "set_documents_folder".to_string(),
+                    reason: e,
+                }
             }
-        } else {
-            CommandError::OperationFailed {
-                operation: "set_documents_folder".to_string(),
-                reason: e,
-            }
-        }
-    })?;
+        })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("Documents folder set to: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -169,25 +182,29 @@ pub async fn set_steam_workshop_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Setting Steam workshop folder to: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths.set_steam_workshop_folder(&path).map_err(|e| {
-        if e.contains("does not exist") {
-            CommandError::NotFound {
-                item: format!("Path: {path}"),
+        paths.set_steam_workshop_folder(&path).map_err(|e| {
+            if e.contains("does not exist") {
+                CommandError::NotFound {
+                    item: format!("Path: {path}"),
+                }
+            } else {
+                CommandError::OperationFailed {
+                    operation: "set_steam_workshop_folder".to_string(),
+                    reason: e,
+                }
             }
-        } else {
-            CommandError::OperationFailed {
-                operation: "set_steam_workshop_folder".to_string(),
-                reason: e,
-            }
-        }
-    })?;
+        })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("Steam workshop folder set to: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -198,25 +215,29 @@ pub async fn add_override_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Adding override folder: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths.add_custom_override_folder(&path).map_err(|e| {
-        if e.contains("does not exist") {
-            CommandError::NotFound {
-                item: format!("Path: {path}"),
+        paths.add_custom_override_folder(&path).map_err(|e| {
+            if e.contains("does not exist") {
+                CommandError::NotFound {
+                    item: format!("Path: {path}"),
+                }
+            } else {
+                CommandError::OperationFailed {
+                    operation: "add_override_folder".to_string(),
+                    reason: e,
+                }
             }
-        } else {
-            CommandError::OperationFailed {
-                operation: "add_override_folder".to_string(),
-                reason: e,
-            }
-        }
-    })?;
+        })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("Override folder added: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -227,19 +248,23 @@ pub async fn remove_override_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Removing override folder: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths
-        .remove_custom_override_folder(&path)
-        .map_err(|e| CommandError::OperationFailed {
-            operation: "remove_override_folder".to_string(),
-            reason: e,
-        })?;
+        paths
+            .remove_custom_override_folder(&path)
+            .map_err(|e| CommandError::OperationFailed {
+                operation: "remove_override_folder".to_string(),
+                reason: e,
+            })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("Override folder removed: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -250,25 +275,29 @@ pub async fn add_hak_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Adding HAK folder: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths.add_custom_hak_folder(&path).map_err(|e| {
-        if e.contains("does not exist") {
-            CommandError::NotFound {
-                item: format!("Path: {path}"),
+        paths.add_custom_hak_folder(&path).map_err(|e| {
+            if e.contains("does not exist") {
+                CommandError::NotFound {
+                    item: format!("Path: {path}"),
+                }
+            } else {
+                CommandError::OperationFailed {
+                    operation: "add_hak_folder".to_string(),
+                    reason: e,
+                }
             }
-        } else {
-            CommandError::OperationFailed {
-                operation: "add_hak_folder".to_string(),
-                reason: e,
-            }
-        }
-    })?;
+        })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("HAK folder added: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -279,19 +308,23 @@ pub async fn remove_hak_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Removing HAK folder: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths
-        .remove_custom_hak_folder(&path)
-        .map_err(|e| CommandError::OperationFailed {
-            operation: "remove_hak_folder".to_string(),
-            reason: e,
-        })?;
+        paths
+            .remove_custom_hak_folder(&path)
+            .map_err(|e| CommandError::OperationFailed {
+                operation: "remove_hak_folder".to_string(),
+                reason: e,
+            })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("HAK folder removed: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -299,19 +332,23 @@ pub async fn remove_hak_folder(
 #[instrument(name = "reset_game_folder", skip(state))]
 pub async fn reset_game_folder(state: State<'_, AppState>) -> CommandResult<PathUpdateResponse> {
     debug!("Resetting game folder to auto-detected");
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths
-        .reset_game_folder()
-        .map_err(|e| CommandError::OperationFailed {
-            operation: "reset_game_folder".to_string(),
-            reason: e,
-        })?;
+        paths
+            .reset_game_folder()
+            .map_err(|e| CommandError::OperationFailed {
+                operation: "reset_game_folder".to_string(),
+                reason: e,
+            })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: "Game folder reset to auto-detected".to_string(),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -321,19 +358,23 @@ pub async fn reset_documents_folder(
     state: State<'_, AppState>,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Resetting documents folder to auto-detected");
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths
-        .reset_documents_folder()
-        .map_err(|e| CommandError::OperationFailed {
-            operation: "reset_documents_folder".to_string(),
-            reason: e,
-        })?;
+        paths
+            .reset_documents_folder()
+            .map_err(|e| CommandError::OperationFailed {
+                operation: "reset_documents_folder".to_string(),
+                reason: e,
+            })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: "Documents folder reset to auto-detected".to_string(),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -343,19 +384,23 @@ pub async fn reset_steam_workshop_folder(
     state: State<'_, AppState>,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Resetting Steam workshop folder to auto-detected");
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths
-        .reset_steam_workshop_folder()
-        .map_err(|e| CommandError::OperationFailed {
-            operation: "reset_steam_workshop_folder".to_string(),
-            reason: e,
-        })?;
+        paths
+            .reset_steam_workshop_folder()
+            .map_err(|e| CommandError::OperationFailed {
+                operation: "reset_steam_workshop_folder".to_string(),
+                reason: e,
+            })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: "Steam workshop folder reset to auto-detected".to_string(),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -371,25 +416,29 @@ pub struct AutoDetectResponse {
 #[instrument(name = "auto_detect_paths", skip(state))]
 pub async fn auto_detect_paths(state: State<'_, AppState>) -> CommandResult<AutoDetectResponse> {
     debug!("Auto-detecting all paths");
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    let _ = paths.reset_game_folder();
-    let _ = paths.reset_documents_folder();
-    let _ = paths.reset_steam_workshop_folder();
+        let _ = paths.reset_game_folder();
+        let _ = paths.reset_documents_folder();
+        let _ = paths.reset_steam_workshop_folder();
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
-    let game_installations = paths
+    let game_installations = snapshot
         .game_folder()
         .map(|p| vec![p.to_string_lossy().to_string()])
         .unwrap_or_default();
 
     Ok(AutoDetectResponse {
         game_installations,
-        documents_folder: paths
+        documents_folder: snapshot
             .documents_folder()
             .map(|p| p.to_string_lossy().to_string()),
-        steam_workshop: paths
+        steam_workshop: snapshot
             .steam_workshop_folder()
             .map(|p| p.to_string_lossy().to_string()),
-        current_paths: build_path_config(&paths),
+        current_paths: build_path_config(&snapshot),
     })
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1,4 +1,8 @@
+use crate::character::Character;
 use crate::commands::{CommandError, CommandResult};
+use crate::loaders::GameData;
+use crate::parsers::gff::GffParser;
+use crate::services::savegame_handler::SaveGameHandler;
 use crate::state::AppState;
 use tauri::{AppHandle, Manager, State};
 use tracing::{error, info, instrument, warn};
@@ -9,14 +13,20 @@ pub async fn load_character(
     state: State<'_, AppState>,
     app: AppHandle,
     file_path: String,
+    player_index: Option<usize>,
 ) -> CommandResult<bool> {
     info!("Load character command invoked");
 
     let mut session = state.session.write();
-    match session.load_character(&file_path) {
+    match session.load_character(&file_path, player_index) {
         Ok(()) => {
             info!("Character loaded successfully via command");
             drop(session);
+            {
+                let game_data = state.game_data.read();
+                let mut session = state.session.write();
+                session.normalize_loaded_skill_points(&game_data);
+            }
             tokio::spawn(async move {
                 let state = app.state::<AppState>();
                 let cache = {
@@ -42,9 +52,102 @@ pub async fn load_character(
         }
         Err(e) => {
             error!("Failed to load character: {}", e);
-            Err(CommandError::CharacterNotFound { path: file_path })
+            Err(CommandError::FileError {
+                message: e,
+                path: Some(file_path),
+            })
         }
     }
+}
+
+#[derive(Clone, serde::Serialize, specta::Type)]
+pub struct SaveCharacterClass {
+    pub name: String,
+    pub level: u8,
+}
+
+#[derive(Clone, serde::Serialize, specta::Type)]
+pub struct SaveCharacterOption {
+    pub player_index: usize,
+    pub name: String,
+    pub race: String,
+    pub total_level: i32,
+    pub classes: Vec<SaveCharacterClass>,
+}
+
+fn summarize_save_character(
+    player_index: usize,
+    character: Character,
+    game_data: &GameData,
+) -> SaveCharacterOption {
+    let name = {
+        let full_name = character.full_name();
+        if full_name.trim().is_empty() {
+            format!("Player {}", player_index + 1)
+        } else {
+            full_name
+        }
+    };
+
+    let classes = character
+        .class_entries()
+        .into_iter()
+        .map(|entry| SaveCharacterClass {
+            name: character.get_class_name(entry.class_id, game_data),
+            level: entry.level.clamp(0, i32::from(u8::MAX)) as u8,
+        })
+        .collect();
+
+    SaveCharacterOption {
+        player_index,
+        name,
+        race: character.race_name(game_data),
+        total_level: character.total_level(),
+        classes,
+    }
+}
+
+#[tauri::command]
+#[instrument(name = "list_save_characters_command", skip(state), fields(file_path = %file_path))]
+pub async fn list_save_characters(
+    state: State<'_, AppState>,
+    file_path: String,
+) -> CommandResult<Vec<SaveCharacterOption>> {
+    let handler = SaveGameHandler::new(&file_path, false, false).map_err(CommandError::from)?;
+    let playerlist_data = handler.extract_player_data().map_err(CommandError::from)?;
+    let gff = GffParser::from_bytes(playerlist_data).map_err(|e| CommandError::ParseError {
+        message: format!("Failed to parse playerlist.ifo: {e}"),
+        context: Some(file_path.clone()),
+    })?;
+
+    let mut player_entries =
+        crate::state::session_state::read_playerlist_entries(gff).map_err(|message| {
+            CommandError::ParseError {
+                message,
+                context: Some(file_path.clone()),
+            }
+        })?;
+
+    if let Ok(Some(player_bic_data)) = handler.extract_player_bic()
+        && let Ok(primary_fields) =
+            crate::state::session_state::read_player_bic_entry(player_bic_data)
+        && let Some(primary_index) = crate::state::session_state::resolve_primary_player_index(
+            &player_entries,
+            Some(&primary_fields),
+        )
+        && let Some(primary_entry) = player_entries.get_mut(primary_index)
+    {
+        *primary_entry = primary_fields;
+    }
+
+    let game_data = state.game_data.read();
+    Ok(player_entries
+        .into_iter()
+        .enumerate()
+        .map(|(player_index, fields)| {
+            summarize_save_character(player_index, Character::from_gff(fields), &game_data)
+        })
+        .collect())
 }
 
 #[tauri::command]
@@ -55,8 +158,9 @@ pub async fn save_character(
 ) -> CommandResult<bool> {
     info!("Save character command invoked");
 
+    let game_data = state.game_data.read();
     let mut session = state.session.write();
-    match session.save_character() {
+    match session.save_character(&game_data) {
         Ok(()) => {
             info!("Character saved successfully via command");
             Ok(true)
@@ -89,6 +193,7 @@ pub struct SessionInfo {
     pub character_loaded: bool,
     pub file_path: Option<String>,
     pub dirty: bool,
+    pub player_index: Option<usize>,
 }
 
 #[tauri::command]
@@ -101,6 +206,10 @@ pub async fn get_session_info(state: State<'_, AppState>) -> CommandResult<Sessi
             .as_ref()
             .map(|p| p.to_string_lossy().to_string()),
         dirty: session.has_unsaved_changes(),
+        player_index: session
+            .character
+            .as_ref()
+            .map(|_| session.selected_player_index),
     })
 }
 

--- a/src-tauri/src/config/nwn2_paths.rs
+++ b/src-tauri/src/config/nwn2_paths.rs
@@ -133,32 +133,38 @@ impl NWN2Paths {
             }
         }
 
-        if self.game_folder.is_none() {
-            self.auto_discover();
+        if self.game_folder.is_none()
+            || self.documents_folder.is_none()
+            || self.steam_workshop_folder.is_none()
+        {
+            self.auto_discover_missing();
         }
     }
 
-    #[instrument(name = "NWN2Paths::auto_discover", skip(self))]
-    fn auto_discover(&mut self) {
+    #[instrument(name = "NWN2Paths::auto_discover_missing", skip(self))]
+    fn auto_discover_missing(&mut self) {
         debug!("Auto-discovering NWN2 installation paths");
         if let Ok(result) = discover_nwn2_paths_rust(None) {
             debug!(
                 "Path discovery found {} candidates",
                 result.nwn2_paths.len()
             );
-            for path in &result.nwn2_paths {
-                let path = PathBuf::from(path);
-                if !path.to_string_lossy().contains("Documents")
-                    && !path.to_string_lossy().contains("My Documents")
-                {
-                    self.game_folder = Some(path);
-                    self.game_folder_source = PathSource::Discovery;
-                    break;
+            if self.game_folder.is_none() {
+                for path in &result.nwn2_paths {
+                    let path = PathBuf::from(path);
+                    if !path.to_string_lossy().contains("Documents")
+                        && !path.to_string_lossy().contains("My Documents")
+                    {
+                        self.game_folder = Some(path);
+                        self.game_folder_source = PathSource::Discovery;
+                        break;
+                    }
                 }
-            }
-            if self.game_folder.is_none() && !result.nwn2_paths.is_empty() {
-                self.game_folder = Some(PathBuf::from(&result.nwn2_paths[0]));
-                self.game_folder_source = PathSource::Discovery;
+
+                if self.game_folder.is_none() && !result.nwn2_paths.is_empty() {
+                    self.game_folder = Some(PathBuf::from(&result.nwn2_paths[0]));
+                    self.game_folder_source = PathSource::Discovery;
+                }
             }
 
             if self.documents_folder.is_none() {
@@ -178,6 +184,9 @@ impl NWN2Paths {
     }
 
     fn get_config_path() -> Option<PathBuf> {
+        if let Ok(override_path) = std::env::var("NWN2EE_SETTINGS_PATH") {
+            return Some(PathBuf::from(override_path));
+        }
         dirs::data_dir().map(|d| d.join("nwn2_save_editor").join("settings.json"))
     }
 
@@ -251,19 +260,42 @@ impl NWN2Paths {
 
         #[cfg(not(windows))]
         {
-            if let Some(home) = dirs::home_dir() {
-                let docs = home.join("Documents").join("Neverwinter Nights 2");
-                if docs.exists() {
-                    return Some(docs);
-                }
-                let local = home.join(".local/share/Neverwinter Nights 2");
-                if local.exists() {
-                    return Some(local);
+            for candidate in Self::non_windows_documents_candidates() {
+                if candidate.exists() {
+                    return Some(candidate);
                 }
             }
         }
 
         None
+    }
+
+    #[cfg(not(windows))]
+    fn non_windows_documents_candidates() -> Vec<PathBuf> {
+        let mut candidates = Vec::new();
+
+        if let Some(home) = dirs::home_dir() {
+            candidates.push(home.join("Documents").join("Neverwinter Nights 2"));
+            candidates.push(home.join(".local/share/Neverwinter Nights 2"));
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            if let Ok(userprofile) = std::env::var("USERPROFILE")
+                && let Some(wsl_home) = windows_profile_to_wsl_home(&userprofile)
+            {
+                candidates.push(wsl_home.join("Documents").join("Neverwinter Nights 2"));
+                candidates.push(wsl_home.join("My Documents").join("Neverwinter Nights 2"));
+            }
+
+            if let Ok(username) = std::env::var("USER") {
+                let wsl_home = PathBuf::from("/mnt/c/Users").join(username);
+                candidates.push(wsl_home.join("Documents").join("Neverwinter Nights 2"));
+                candidates.push(wsl_home.join("My Documents").join("Neverwinter Nights 2"));
+            }
+        }
+
+        candidates
     }
 
     fn find_steam_workshop() -> Option<PathBuf> {
@@ -317,7 +349,7 @@ impl NWN2Paths {
     pub fn reset_game_folder(&mut self) -> Result<(), String> {
         self.game_folder = None;
         self.game_folder_source = PathSource::Discovery;
-        self.auto_discover();
+        self.auto_discover_missing();
         self.save_settings().map_err(|e| e.to_string())?;
         Ok(())
     }
@@ -524,6 +556,30 @@ impl NWN2Paths {
     }
 }
 
+#[cfg(all(target_os = "linux", not(windows)))]
+fn windows_profile_to_wsl_home(userprofile: &str) -> Option<PathBuf> {
+    let normalized = userprofile.replace('\\', "/");
+    let mut chars = normalized.chars();
+
+    let drive = chars.next()?;
+    if chars.next()? != ':' {
+        return None;
+    }
+
+    let mut remainder = chars.as_str().trim_start_matches('/').to_string();
+    if remainder.is_empty() {
+        return None;
+    }
+
+    remainder = remainder.trim_end_matches('/').to_string();
+
+    Some(PathBuf::from(format!(
+        "/mnt/{}/{}",
+        drive.to_ascii_lowercase(),
+        remainder
+    )))
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct NWN2PathsConfig {
     game_folder: Option<String>,
@@ -535,4 +591,46 @@ struct NWN2PathsConfig {
     custom_module_folders: Vec<String>,
     #[serde(default)]
     custom_hak_folders: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NWN2Paths;
+    use std::sync::{LazyLock, Mutex};
+    use tempfile::TempDir;
+
+    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    fn with_test_settings_path<T>(temp_dir: &TempDir, test: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().expect("env mutex poisoned");
+        let settings_path = temp_dir.path().join("settings.json");
+        let old_settings = std::env::var("NWN2EE_SETTINGS_PATH").ok();
+
+        unsafe {
+            std::env::set_var("NWN2EE_SETTINGS_PATH", &settings_path);
+        }
+
+        let result = test();
+
+        unsafe {
+            if let Some(value) = old_settings {
+                std::env::set_var("NWN2EE_SETTINGS_PATH", value);
+            } else {
+                std::env::remove_var("NWN2EE_SETTINGS_PATH");
+            }
+        }
+
+        result
+    }
+
+    #[test]
+    fn test_save_settings_respects_override_path() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+
+        with_test_settings_path(&temp_dir, || {
+            let paths = NWN2Paths::new();
+            paths.save_settings().expect("failed to save settings");
+            assert!(temp_dir.path().join("settings.json").exists());
+        });
+    }
 }

--- a/src-tauri/src/file_operations.rs
+++ b/src-tauri/src/file_operations.rs
@@ -5,6 +5,24 @@ use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_shell::ShellExt;
 
 use crate::services::playerinfo::PlayerInfo;
+use crate::services::savegame_handler::SaveGameHandler;
+
+fn read_save_character_name(save_path: &std::path::Path) -> Option<String> {
+    if let Ok(handler) = SaveGameHandler::new(save_path, false, false)
+        && let Ok(Some(summary)) = handler.read_character_summary()
+    {
+        let name = [summary.first_name, summary.last_name]
+            .into_iter()
+            .filter(|part| !part.trim().is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        if !name.trim().is_empty() {
+            return Some(name);
+        }
+    }
+
+    PlayerInfo::get_player_name(save_path.join("playerinfo.bin")).ok()
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone, specta::Type)]
 pub struct SaveFile {
@@ -83,7 +101,7 @@ pub async fn select_save_file(app: tauri::AppHandle) -> Result<SaveFile, String>
                 .as_secs() as i64
         });
 
-    let character_name = PlayerInfo::get_player_name(save_path.join("playerinfo.bin")).ok();
+    let character_name = read_save_character_name(&save_path);
 
     Ok(SaveFile {
         path: path_str,
@@ -111,16 +129,24 @@ pub async fn select_nwn2_directory(app: tauri::AppHandle) -> Result<String, Stri
 }
 
 #[tauri::command]
-pub async fn find_nwn2_saves(_app: tauri::AppHandle) -> Result<Vec<SaveFile>, String> {
+pub async fn find_nwn2_saves(
+    _app: tauri::AppHandle,
+    save_mode: Option<String>,
+) -> Result<Vec<SaveFile>, String> {
     use std::time::Instant;
     let start_time = Instant::now();
     log::info!("[Rust] Finding available NWN2 saves.");
 
     // Use NWN2Paths to get saves directory
     let nwn2_paths = crate::config::nwn2_paths::NWN2Paths::new();
-    let saves_path = nwn2_paths
+    let base_saves_path = nwn2_paths
         .saves()
         .ok_or("Could not determine NWN2 saves path")?;
+    let saves_path = if save_mode.as_deref() == Some("mp") {
+        base_saves_path.join("multiplayer")
+    } else {
+        base_saves_path
+    };
     let mut saves = Vec::new();
 
     let scan_start = Instant::now();
@@ -177,8 +203,7 @@ pub async fn find_nwn2_saves(_app: tauri::AppHandle) -> Result<Vec<SaveFile>, St
                         .as_secs() as i64
                 });
 
-            let character_name =
-                PlayerInfo::get_player_name(entry.path().join("playerinfo.bin")).ok();
+            let character_name = read_save_character_name(&entry.path());
 
             saves.push(SaveFile {
                 name: save_name,
@@ -514,23 +539,7 @@ pub async fn browse_saves(
             .ok()
             .map(|s| s.trim().to_string());
 
-        let playerinfo_path = entry_path.join("playerinfo.bin");
-        let character_name = match PlayerInfo::get_player_name(&playerinfo_path) {
-            Ok(name) => {
-                log::debug!(
-                    "[browse_saves] Parsed character name: {name} from {}",
-                    playerinfo_path.display()
-                );
-                Some(name)
-            }
-            Err(e) => {
-                log::debug!(
-                    "[browse_saves] Failed to parse playerinfo.bin at {}: {e}",
-                    playerinfo_path.display()
-                );
-                None
-            }
-        };
+        let character_name = read_save_character_name(&entry_path);
 
         let thumbnail_path = entry_path.join("screen.tga");
         let thumbnail = if thumbnail_path.exists() {
@@ -578,11 +587,16 @@ pub async fn browse_saves(
 }
 
 #[tauri::command]
-pub async fn get_default_saves_path() -> Result<String, String> {
+pub async fn get_default_saves_path(save_mode: Option<String>) -> Result<String, String> {
     let nwn2_paths = crate::config::nwn2_paths::NWN2Paths::new();
-    let saves_path = nwn2_paths
+    let base_saves_path = nwn2_paths
         .saves()
         .ok_or("Could not determine NWN2 saves path")?;
+    let saves_path = if save_mode.as_deref() == Some("mp") {
+        base_saves_path.join("multiplayer")
+    } else {
+        base_saves_path
+    };
     Ok(saves_path.to_string_lossy().to_string())
 }
 
@@ -674,8 +688,7 @@ pub async fn browse_backups(path: String) -> Result<Vec<BrowseBackupEntry>, Stri
             }
         }
 
-        let playerinfo_path = entry_path.join("playerinfo.bin");
-        let character_name = PlayerInfo::get_player_name(&playerinfo_path).ok();
+        let character_name = read_save_character_name(&entry_path);
 
         let save_name = std::fs::read_to_string(entry_path.join("savename.txt"))
             .ok()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,6 +83,7 @@ pub fn run() {
             get_default_localvault_path,
             // Session
             crate::commands::session::load_character,
+            crate::commands::session::list_save_characters,
             crate::commands::session::save_character,
             crate::commands::session::close_character,
             crate::commands::session::get_session_info,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,9 +18,8 @@ use tracing::{debug, info};
 use file_operations::{
     browse_backups, browse_localvault, browse_saves, detect_nwn2_installation, find_nwn2_saves,
     get_default_backups_path, get_default_localvault_path, get_default_saves_path,
-    get_save_thumbnail,
-    get_steam_workshop_path, launch_nwn2_game, open_folder_in_explorer, select_nwn2_directory,
-    select_save_file, validate_nwn2_installation,
+    get_save_thumbnail, get_steam_workshop_path, launch_nwn2_game, open_folder_in_explorer,
+    select_nwn2_directory, select_save_file, validate_nwn2_installation,
 };
 use window_manager::{close_settings_window, open_settings_window, show_main_window};
 
@@ -270,7 +269,6 @@ pub fn run() {
             crate::commands::paths::remove_hak_folder,
             crate::commands::paths::reset_game_folder,
             crate::commands::paths::reset_documents_folder,
-            crate::commands::paths::reset_steam_workshop_folder,
             crate::commands::paths::reset_steam_workshop_folder,
             crate::commands::paths::auto_detect_paths,
             // Config

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -19,7 +19,7 @@ use axum::{
 };
 use parking_lot::RwLock;
 use serde::Deserialize;
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 use tokio::sync::{Mutex, mpsc::UnboundedSender};
 use tokio_stream::{StreamExt as _, wrappers::UnboundedReceiverStream};
 
@@ -115,13 +115,10 @@ fn handle_jsonrpc(state: McpState, request: Value) -> Option<Value> {
     let params = request
         .get("params")
         .cloned()
-        .unwrap_or(Value::Object(Default::default()));
+        .unwrap_or(Value::Object(Map::default()));
 
     // Notifications have no id — no response required
-    if id.is_none() {
-        return None;
-    }
-    let id = id.unwrap();
+    let id = id?;
 
     let result = match method {
         "initialize" => Ok(json!({
@@ -135,7 +132,7 @@ fn handle_jsonrpc(state: McpState, request: Value) -> Option<Value> {
             let arguments = params
                 .get("arguments")
                 .cloned()
-                .unwrap_or(Value::Object(Default::default()));
+                .unwrap_or(Value::Object(Map::default()));
             match dispatch_tool(state, tool_name, arguments) {
                 Ok(value) => Ok(json!({
                     "content": [{ "type": "text", "text": serde_json::to_string_pretty(&value).unwrap_or_default() }],

--- a/src-tauri/src/services/playerinfo/mod.rs
+++ b/src-tauri/src/services/playerinfo/mod.rs
@@ -362,8 +362,7 @@ fn write_string(writer: &mut impl Write, s: &str) -> PlayerInfoResult<()> {
 
 fn extract_string(fields: &IndexMap<String, GffValue<'_>>, key: &str) -> Option<String> {
     match fields.get(key)? {
-        GffValue::String(s) => Some(s.to_string()),
-        GffValue::ResRef(s) => Some(s.to_string()),
+        GffValue::String(s) | GffValue::ResRef(s) => Some(s.to_string()),
         _ => None,
     }
 }
@@ -418,4 +417,5 @@ mod tests {
 
         assert_eq!(result, "");
     }
+
 }

--- a/src-tauri/src/services/resource_manager/mod.rs
+++ b/src-tauri/src/services/resource_manager/mod.rs
@@ -125,6 +125,37 @@ impl ResourceManager {
         Ok(())
     }
 
+    pub async fn update_paths(&mut self, new_paths: NWN2Paths) {
+        {
+            let mut paths = self.paths.write().await;
+            *paths = new_paths;
+        }
+
+        self.initialized = false;
+        self.tda_locations.clear();
+        self.template_locations.clear();
+        self.tlk_cache = None;
+        self.custom_tlk_cache = None;
+        self.hak_overrides.clear();
+        self.module_overrides.clear();
+        self.campaign_overrides.clear();
+        self.override_dir_cache.clear();
+        self.workshop_cache.clear();
+        self.custom_override_cache.clear();
+        self.base_game_cache.clear();
+        self.override_file_paths.clear();
+        self.workshop_file_paths.clear();
+        self.custom_override_paths.clear();
+        self.campaign_override_paths.clear();
+        self.current_module = None;
+        self.module_path = None;
+        self.module_info = None;
+        self.current_campaign_id = None;
+        self.current_campaign_folder = None;
+        self.module_cache.clear();
+        self.file_mod_tracker.clear();
+    }
+
     async fn scan_base_game_zips(&mut self) -> ResourceManagerResult<()> {
         let paths = self.paths.read().await;
         let data_dir = paths

--- a/src-tauri/src/services/savegame_handler/mod.rs
+++ b/src-tauri/src/services/savegame_handler/mod.rs
@@ -330,7 +330,7 @@ impl SaveGameHandler {
     pub fn update_player_complete(
         &mut self,
         playerlist_content: &[u8],
-        playerbic_content: &[u8],
+        playerbic_content: Option<&[u8]>,
         _base_stats: Option<&CharacterStats>,
         _char_summary: Option<&CharacterSummary>,
     ) -> SaveGameResult<()> {
@@ -348,7 +348,7 @@ impl SaveGameHandler {
                 .last_modified_time(*NWN2_DATE_TIME);
 
             let mut playerlist_written = false;
-            let mut playerbic_written = false;
+            let mut playerbic_present = false;
 
             for i in 0..src_archive.len() {
                 let mut src_entry = src_archive.by_index(i)?;
@@ -359,9 +359,15 @@ impl SaveGameHandler {
                     dst_archive.write_all(playerlist_content)?;
                     playerlist_written = true;
                 } else if name == PLAYER_BIC {
+                    playerbic_present = true;
                     dst_archive.start_file(&name, options)?;
-                    dst_archive.write_all(playerbic_content)?;
-                    playerbic_written = true;
+                    if let Some(playerbic_content) = playerbic_content {
+                        dst_archive.write_all(playerbic_content)?;
+                    } else {
+                        let mut buffer = Vec::with_capacity(src_entry.size() as usize);
+                        src_entry.read_to_end(&mut buffer)?;
+                        dst_archive.write_all(&buffer)?;
+                    }
                 } else {
                     dst_archive.start_file(&name, options)?;
                     let mut buffer = Vec::with_capacity(src_entry.size() as usize);
@@ -375,7 +381,7 @@ impl SaveGameHandler {
                 dst_archive.write_all(playerlist_content)?;
             }
 
-            if !playerbic_written {
+            if !playerbic_present && let Some(playerbic_content) = playerbic_content {
                 dst_archive.start_file(PLAYER_BIC, options)?;
                 dst_archive.write_all(playerbic_content)?;
             }

--- a/src-tauri/src/state/session_state.rs
+++ b/src-tauri/src/state/session_state.rs
@@ -1,17 +1,22 @@
-use std::path::PathBuf;
+use indexmap::IndexMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, info, instrument, warn};
 
 use crate::character::{Character, FeatInfo};
+use crate::loaders::GameData;
+use crate::parsers::gff::{GffParser, GffValue, GffWriter};
+use crate::services::item_property_decoder::ItemPropertyDecoder;
 use crate::services::resource_manager::ResourceManager;
 use crate::services::savegame_handler::SaveGameHandler;
-
-use crate::services::item_property_decoder::ItemPropertyDecoder;
+use crate::services::PlayerInfo;
 
 pub struct SessionState {
     pub current_file_path: Option<PathBuf>,
     pub savegame_handler: Option<SaveGameHandler>,
     pub character: Option<Character>,
+    pub selected_player_index: usize,
+    pub primary_player_index: Option<usize>,
     pub item_property_decoder: ItemPropertyDecoder,
     pub feat_cache: Option<Vec<FeatInfo>>,
 }
@@ -31,13 +36,19 @@ impl SessionState {
             current_file_path: None,
             savegame_handler: None,
             character: None,
+            selected_player_index: 0,
+            primary_player_index: None,
             item_property_decoder,
             feat_cache: None,
         }
     }
 
     #[instrument(name = "SessionState::load_character", skip(self), fields(file_path = %file_path))]
-    pub fn load_character(&mut self, file_path: &str) -> Result<(), String> {
+    pub fn load_character(
+        &mut self,
+        file_path: &str,
+        player_index: Option<usize>,
+    ) -> Result<(), String> {
         info!("Loading character from save file");
         let path = PathBuf::from(file_path);
 
@@ -57,37 +68,44 @@ impl SessionState {
         })?;
         info!("playerlist.ifo extracted ({} bytes)", playerlist_data.len());
 
-        debug!("Parsing GFF data");
-        let gff = crate::parsers::gff::GffParser::from_bytes(playerlist_data).map_err(|e| {
+        debug!("Parsing playerlist.ifo GFF data");
+        let gff = GffParser::from_bytes(playerlist_data).map_err(|e| {
             warn!("GFF parse error: {}", e);
             format!("GFF Parse error: {e}")
         })?;
-        debug!("GFF parsed successfully");
+        debug!("playerlist.ifo parsed successfully");
 
-        debug!("Reading playerlist.ifo root struct");
-        let root_fields = gff.read_struct_fields(0).map_err(|e| {
-            warn!("Failed to read root struct: {}", e);
-            format!("Failed to read root struct: {e}")
-        })?;
-
-        debug!("Extracting Mod_PlayerList[0] (character data)");
-        let fields = {
-            use crate::parsers::gff::GffValue;
-            let mod_player_list = root_fields.get("Mod_PlayerList").ok_or_else(|| {
-                warn!("Mod_PlayerList not found in playerlist.ifo");
-                "Mod_PlayerList not found in playerlist.ifo".to_string()
-            })?;
-
-            if let GffValue::List(lazy_structs) = mod_player_list {
-                let first = lazy_structs.first().ok_or_else(|| {
-                    warn!("Mod_PlayerList is empty");
-                    "Mod_PlayerList is empty".to_string()
-                })?;
-                first.force_load()
-            } else {
-                warn!("Mod_PlayerList is not a list");
-                return Err("Mod_PlayerList is not a list".to_string());
+        let player_entries = read_playerlist_entries(gff)?;
+        let player_bic_fields = match handler.extract_player_bic() {
+            Ok(Some(player_bic_data)) => match read_player_bic_entry(player_bic_data) {
+                Ok(fields) => Some(fields),
+                Err(err) => {
+                    warn!("Failed to parse player.bic while loading save: {}", err);
+                    None
+                }
+            },
+            Ok(None) => None,
+            Err(err) => {
+                warn!("Failed to extract player.bic while loading save: {}", err);
+                None
             }
+        };
+        let primary_player_index =
+            resolve_primary_player_index(&player_entries, player_bic_fields.as_ref());
+        let selected_player_index = player_index.unwrap_or(primary_player_index.unwrap_or(0));
+
+        let fields = if primary_player_index == Some(selected_player_index) {
+            if let Some(fields) = player_bic_fields {
+                debug!(
+                    "Using player.bic as authoritative source for playerlist slot {}",
+                    selected_player_index
+                );
+                fields
+            } else {
+                read_playerlist_entry_from_entries(&player_entries, selected_player_index)?
+            }
+        } else {
+            read_playerlist_entry_from_entries(&player_entries, selected_player_index)?
         };
         info!("Character data extracted ({} fields)", fields.len());
 
@@ -102,19 +120,86 @@ impl SessionState {
         self.character = Some(character);
         self.savegame_handler = Some(handler);
         self.current_file_path = Some(path);
+        self.selected_player_index = selected_player_index;
+        self.primary_player_index = primary_player_index;
 
         info!("Character loaded successfully");
         Ok(())
     }
 
-    pub fn save_character(&mut self) -> Result<(), String> {
-        let _handler = self
-            .savegame_handler
-            .as_mut()
-            .ok_or("No active save handler")?;
-        let _character = self.character.as_ref().ok_or("No character loaded")?;
+    pub fn normalize_loaded_skill_points(&mut self, game_data: &GameData) {
+        let Some(character) = self.character.as_mut() else {
+            return;
+        };
 
-        // TODO: serialize character data to GFF and write to save file
+        let summary = character.get_skill_points_summary(game_data);
+        if summary.mismatch == 0 {
+            return;
+        }
+
+        let was_modified = character.is_modified();
+        character.normalize_skill_points(game_data);
+
+        if !was_modified {
+            character.mark_saved();
+        }
+    }
+
+    pub fn save_character(&mut self, game_data: &GameData) -> Result<(), String> {
+        if self.savegame_handler.is_none() {
+            return Err("No active save handler".to_string());
+        }
+        if self.character.is_none() {
+            return Err("No character loaded".to_string());
+        }
+
+        let char_fields = {
+            let character = self.character.as_mut().unwrap();
+            character.normalize_skill_points(game_data);
+            character
+                .recalculate_stats(game_data)
+                .map_err(|e| format!("Failed to recalculate class-derived stats: {e}"))?;
+            character.clone_gff()
+        };
+
+        let (playerlist_data, player_bic_data) = {
+            let handler = self.savegame_handler.as_ref().unwrap();
+            let playerlist_data = handler
+                .extract_player_data()
+                .map_err(|e| format!("Failed to read playerlist.ifo: {e}"))?;
+            let player_bic_data = handler
+                .extract_player_bic()
+                .map_err(|e| format!("Failed to read player.bic: {e}"))?;
+            (playerlist_data, player_bic_data)
+        };
+
+        let playerlist_bytes =
+            serialize_playerlist_bytes(playerlist_data, &char_fields, self.selected_player_index)?;
+        let update_primary_player_files =
+            self.primary_player_index == Some(self.selected_player_index);
+        let player_bic_bytes = if update_primary_player_files {
+            Some(serialize_player_bic_bytes(player_bic_data, &char_fields)?)
+        } else {
+            None
+        };
+
+        self.savegame_handler
+            .as_mut()
+            .unwrap()
+            .update_player_complete(&playerlist_bytes, player_bic_bytes.as_deref(), None, None)
+            .map_err(|e| format!("Failed to write save file: {e}"))?;
+
+        if update_primary_player_files {
+            self.write_playerinfo(game_data)?;
+        }
+
+        self.character.as_mut().unwrap().mark_saved();
+
+        info!(
+            "Character saved successfully (playerlist={} bytes, player.bic_updated={})",
+            playerlist_bytes.len(),
+            update_primary_player_files
+        );
         Ok(())
     }
 
@@ -122,6 +207,8 @@ impl SessionState {
         self.character = None;
         self.savegame_handler = None;
         self.current_file_path = None;
+        self.selected_player_index = 0;
+        self.primary_player_index = None;
         self.feat_cache = None;
         crate::services::savegame_handler::backup::clear_backup_tracking();
     }
@@ -144,6 +231,28 @@ impl SessionState {
         self.character.as_mut()
     }
 
+    fn current_save_dir(&self) -> Result<PathBuf, String> {
+        let current_path = self
+            .current_file_path
+            .as_ref()
+            .ok_or("No current save path")?;
+
+        if current_path.is_dir() {
+            Ok(current_path.clone())
+        } else {
+            current_path
+                .parent()
+                .map(PathBuf::from)
+                .ok_or_else(|| "Failed to determine save directory".to_string())
+        }
+    }
+
+    fn write_playerinfo(&self, game_data: &GameData) -> Result<(), String> {
+        let character = self.character.as_ref().ok_or("No character loaded")?;
+        let save_dir = self.current_save_dir()?;
+        write_playerinfo_for_character(&save_dir, character, game_data)
+    }
+
     #[instrument(name = "SessionState::export_to_localvault", skip(self))]
     pub fn export_to_localvault(&self) -> Result<String, String> {
         let handler = self
@@ -164,8 +273,9 @@ impl SessionState {
 
         let player_bic_data = handler
             .extract_player_bic()
-            .map_err(|e| format!("Failed to extract player.bic: {e}"))?
-            .ok_or("No player.bic found in save")?;
+            .map_err(|e| format!("Failed to extract player.bic: {e}"))?;
+        let current_character_fields = character.clone_gff();
+        let player_bic_bytes = serialize_player_bic_bytes(player_bic_data, &current_character_fields)?;
 
         let first_name = character.first_name();
         let last_name = character.last_name();
@@ -182,11 +292,242 @@ impl SessionState {
 
         let dest_path = vault_path.join(&sanitized_filename);
 
-        std::fs::write(&dest_path, &player_bic_data)
+        std::fs::write(&dest_path, &player_bic_bytes)
             .map_err(|e| format!("Failed to write character to vault: {e}"))?;
 
         info!("Exported character to vault: {}", dest_path.display());
 
         Ok(dest_path.to_string_lossy().to_string())
     }
+}
+
+fn write_playerinfo_for_character(
+    save_dir: &Path,
+    character: &Character,
+    game_data: &GameData,
+) -> Result<(), String> {
+    let playerinfo_path = save_dir.join("playerinfo.bin");
+
+    let mut player_info = if playerinfo_path.exists() {
+        PlayerInfo::load(&playerinfo_path)
+            .map_err(|e| format!("Failed to read playerinfo.bin: {e}"))?
+    } else {
+        PlayerInfo::new()
+    };
+
+    let subrace_label = character.subrace_name(game_data).unwrap_or_default();
+    let alignment_name = character.alignment().alignment_string();
+    let classes = character
+        .class_entries()
+        .into_iter()
+        .map(|entry| {
+            let level = entry.level.clamp(0, i32::from(u8::MAX)) as u8;
+            (character.get_class_name(entry.class_id, game_data), level)
+        })
+        .collect::<Vec<_>>();
+
+    player_info.update_from_gff_data(character.gff(), &subrace_label, &alignment_name, &classes);
+    player_info
+        .save(&playerinfo_path)
+        .map_err(|e| format!("Failed to write playerinfo.bin: {e}"))?;
+
+    Ok(())
+}
+
+fn serialize_playerlist_bytes(
+    playerlist_data: Vec<u8>,
+    character_fields: &IndexMap<String, GffValue<'static>>,
+    player_index: usize,
+) -> Result<Vec<u8>, String> {
+    let gff = GffParser::from_bytes(playerlist_data)
+        .map_err(|e| format!("playerlist.ifo parse error: {e}"))?;
+
+    let file_type = gff.file_type.clone();
+    let file_version = gff.file_version.clone();
+
+    let root_fields_raw = gff
+        .read_struct_fields(0)
+        .map_err(|e| format!("Failed to read playerlist.ifo root struct: {e}"))?;
+
+    let mut root_fields: IndexMap<String, GffValue<'static>> = root_fields_raw
+        .into_iter()
+        .map(|(k, v)| (k, v.force_owned()))
+        .collect();
+
+    fn merge_player_entry_fields(
+        existing: &IndexMap<String, GffValue<'static>>,
+        updated_character_fields: &IndexMap<String, GffValue<'static>>,
+    ) -> IndexMap<String, GffValue<'static>> {
+        let mut merged = existing.clone();
+        for (key, value) in updated_character_fields {
+            merged.insert(key.clone(), value.clone());
+        }
+        merged
+    }
+
+    match root_fields.get_mut("Mod_PlayerList") {
+        Some(GffValue::ListOwned(players)) => {
+            if players.is_empty() {
+                if player_index == 0 {
+                    players.push(character_fields.clone());
+                } else {
+                    return Err(format!(
+                        "Selected player index {player_index} is out of range for an empty Mod_PlayerList"
+                    ));
+                }
+            } else {
+                let Some(player_entry) = players.get_mut(player_index) else {
+                    return Err(format!(
+                        "Selected player index {player_index} is out of range for Mod_PlayerList with {} entries",
+                        players.len()
+                    ));
+                };
+                *player_entry = merge_player_entry_fields(player_entry, character_fields);
+            }
+        }
+        Some(_) => {
+            return Err("Mod_PlayerList in playerlist.ifo is not a list".to_string());
+        }
+        None => {
+            if player_index == 0 {
+                root_fields.insert(
+                    "Mod_PlayerList".to_string(),
+                    GffValue::ListOwned(vec![character_fields.clone()]),
+                );
+            } else {
+                return Err(format!(
+                    "Selected player index {player_index} is out of range because Mod_PlayerList is missing"
+                ));
+            }
+        }
+    }
+
+    GffWriter::new(&file_type, &file_version)
+        .write(root_fields)
+        .map_err(|e| format!("playerlist.ifo serialization error: {e}"))
+}
+
+pub(crate) fn read_playerlist_entries(
+    gff: Arc<GffParser>,
+) -> Result<Vec<IndexMap<String, GffValue<'static>>>, String> {
+    debug!("Reading playerlist.ifo root struct");
+    let root_fields = gff.read_struct_fields(0).map_err(|e| {
+        warn!("Failed to read root struct: {}", e);
+        format!("Failed to read root struct: {e}")
+    })?;
+
+    let mod_player_list = root_fields.get("Mod_PlayerList").ok_or_else(|| {
+        warn!("Mod_PlayerList not found in playerlist.ifo");
+        "Mod_PlayerList not found in playerlist.ifo".to_string()
+    })?;
+
+    if let GffValue::List(lazy_structs) = mod_player_list {
+        if lazy_structs.is_empty() {
+            warn!("Mod_PlayerList is empty");
+            return Err("Mod_PlayerList is empty".to_string());
+        }
+
+        Ok(lazy_structs
+            .iter()
+            .map(|entry| entry.force_load())
+            .collect())
+    } else {
+        warn!("Mod_PlayerList is not a list");
+        Err("Mod_PlayerList is not a list".to_string())
+    }
+}
+
+fn read_playerlist_entry_from_entries(
+    entries: &[IndexMap<String, GffValue<'static>>],
+    player_index: usize,
+) -> Result<IndexMap<String, GffValue<'static>>, String> {
+    entries.get(player_index).cloned().ok_or_else(|| {
+        format!(
+            "Selected player index {player_index} is out of range for Mod_PlayerList with {} entries",
+            entries.len()
+        )
+    })
+}
+
+pub(crate) fn read_player_bic_entry(
+    player_bic_data: Vec<u8>,
+) -> Result<IndexMap<String, GffValue<'static>>, String> {
+    let gff = GffParser::from_bytes(player_bic_data).map_err(|e| {
+        warn!("Failed to parse player.bic: {}", e);
+        format!("Failed to parse player.bic: {e}")
+    })?;
+
+    let root_fields = gff.read_struct_fields(0).map_err(|e| {
+        warn!("Failed to read player.bic root struct: {}", e);
+        format!("Failed to read player.bic root struct: {e}")
+    })?;
+
+    Ok(root_fields
+        .into_iter()
+        .map(|(key, value)| (key, value.force_owned()))
+        .collect())
+}
+
+pub(crate) fn resolve_primary_player_index(
+    player_entries: &[IndexMap<String, GffValue<'static>>],
+    player_bic_fields: Option<&IndexMap<String, GffValue<'static>>>,
+) -> Option<usize> {
+    if player_entries.len() == 1 {
+        return Some(0);
+    }
+
+    let Some(player_bic_fields) = player_bic_fields else {
+        return None;
+    };
+
+    let player_bic_name = Character::from_gff(player_bic_fields.clone()).full_name();
+    if player_bic_name.trim().is_empty() {
+        warn!("player.bic has no character name; refusing to infer a primary multiplayer slot");
+        return None;
+    }
+
+    let matching_indices = player_entries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, fields)| {
+            (Character::from_gff(fields.clone()).full_name() == player_bic_name).then_some(index)
+        })
+        .collect::<Vec<_>>();
+
+    match matching_indices.as_slice() {
+        [index] => Some(*index),
+        [] => {
+            warn!(
+                "player.bic name '{}' did not match any Mod_PlayerList entry; refusing to infer a primary multiplayer slot",
+                player_bic_name
+            );
+            None
+        }
+        _ => {
+            warn!(
+                "player.bic name '{}' matched multiple Mod_PlayerList entries; refusing to infer a primary multiplayer slot",
+                player_bic_name
+            );
+            None
+        }
+    }
+}
+
+fn serialize_player_bic_bytes(
+    player_bic_data: Option<Vec<u8>>,
+    character_fields: &IndexMap<String, GffValue<'static>>,
+) -> Result<Vec<u8>, String> {
+    let (file_type, file_version) = if let Some(player_bic_data) = player_bic_data {
+        let gff = GffParser::from_bytes(player_bic_data)
+            .map_err(|e| format!("player.bic parse error: {e}"))?;
+        let file_type = gff.file_type.clone();
+        let file_version = gff.file_version.clone();
+        (file_type, file_version)
+    } else {
+        ("BIC ".to_string(), "V3.2".to_string())
+    };
+
+    GffWriter::new(&file_type, &file_version)
+        .write(character_fields.clone())
+        .map_err(|e| format!("player.bic serialization error: {e}"))
 }

--- a/src-tauri/src/state/session_state.rs
+++ b/src-tauri/src/state/session_state.rs
@@ -6,10 +6,10 @@ use tracing::{debug, info, instrument, warn};
 use crate::character::{Character, FeatInfo};
 use crate::loaders::GameData;
 use crate::parsers::gff::{GffParser, GffValue, GffWriter};
+use crate::services::PlayerInfo;
 use crate::services::item_property_decoder::ItemPropertyDecoder;
 use crate::services::resource_manager::ResourceManager;
 use crate::services::savegame_handler::SaveGameHandler;
-use crate::services::PlayerInfo;
 
 pub struct SessionState {
     pub current_file_path: Option<PathBuf>,
@@ -275,7 +275,8 @@ impl SessionState {
             .extract_player_bic()
             .map_err(|e| format!("Failed to extract player.bic: {e}"))?;
         let current_character_fields = character.clone_gff();
-        let player_bic_bytes = serialize_player_bic_bytes(player_bic_data, &current_character_fields)?;
+        let player_bic_bytes =
+            serialize_player_bic_bytes(player_bic_data, &current_character_fields)?;
 
         let first_name = character.first_name();
         let last_name = character.last_name();
@@ -476,9 +477,7 @@ pub(crate) fn resolve_primary_player_index(
         return Some(0);
     }
 
-    let Some(player_bic_fields) = player_bic_fields else {
-        return None;
-    };
+    let player_bic_fields = player_bic_fields?;
 
     let player_bic_name = Character::from_gff(player_bic_fields.clone()).full_name();
     if player_bic_name.trim().is_empty() {

--- a/src-tauri/src/utils/path_discovery.rs
+++ b/src-tauri/src/utils/path_discovery.rs
@@ -1,8 +1,15 @@
-use dirs;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
+
+const KNOWN_GAME_FOLDER_NAMES: &[&str] = &[
+    "NWN2 Enhanced Edition",
+    "Neverwinter Nights 2 Enhanced Edition",
+    "Neverwinter Nights 2",
+    "NWN2",
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PathTiming {
@@ -27,143 +34,55 @@ pub fn discover_nwn2_paths_rust(
     let start_time = Instant::now();
     let mut timing_breakdown = Vec::new();
 
+    let candidate_start = Instant::now();
+    let candidate_paths = if let Some(custom_paths) = search_paths {
+        build_candidate_paths_from_roots(custom_paths.into_iter().map(PathBuf::from).collect())
+    } else {
+        get_default_candidate_paths()
+    };
+    timing_breakdown.push(PathTiming {
+        operation: "candidate_collection".to_string(),
+        duration_ms: candidate_start.elapsed().as_millis() as u64,
+        paths_checked: candidate_paths.len() as u32,
+        paths_found: 0,
+    });
+
+    let validation_start = Instant::now();
     let mut nwn2_paths = Vec::new();
     let mut steam_paths = Vec::new();
     let mut gog_paths = Vec::new();
-
-    let paths_to_search = if let Some(custom_paths) = search_paths {
-        custom_paths.into_iter().map(PathBuf::from).collect()
-    } else {
-        get_default_search_paths()
-    };
-
-    let search_start = Instant::now();
-    let mut paths_checked = 0;
     let mut paths_found = 0;
 
-    for search_path in paths_to_search {
-        if !search_path.exists() {
+    for candidate in &candidate_paths {
+        if !candidate.exists() || !is_nwn2_installation(candidate) {
             continue;
         }
 
-        paths_checked += 1;
+        paths_found += 1;
+        let path_str = candidate.to_string_lossy().to_string();
+        nwn2_paths.push(path_str.clone());
 
-        let patterns = ["Neverwinter Nights 2", "NWN2", "nwn2"];
-
-        if is_nwn2_installation(&search_path) {
-            let path_str = search_path.to_string_lossy().to_string();
-            nwn2_paths.push(path_str.clone());
-            paths_found += 1;
-
-            if path_str.contains("Steam") || path_str.contains("steamapps") {
-                steam_paths.push(path_str);
-            } else if path_str.contains("GOG") {
-                gog_paths.push(path_str);
-            }
-        }
-
-        if let Ok(entries) = std::fs::read_dir(&search_path) {
-            for entry in entries.flatten() {
-                if let Ok(file_type) = entry.file_type()
-                    && file_type.is_dir()
-                    && let Some(name) = entry.file_name().to_str()
-                {
-                    let name_lower = name.to_lowercase();
-                    let matches_pattern = patterns.iter().any(|pattern| {
-                        let pattern_lower = pattern.to_lowercase();
-                        name_lower.contains(&pattern_lower)
-                            || name_lower.starts_with(&pattern_lower)
-                    });
-
-                    if matches_pattern && is_nwn2_installation(&entry.path()) {
-                        let path_str = entry.path().to_string_lossy().to_string();
-                        nwn2_paths.push(path_str.clone());
-                        paths_found += 1;
-
-                        if path_str.contains("Steam") || path_str.contains("steamapps") {
-                            steam_paths.push(path_str);
-                        } else if path_str.contains("GOG") {
-                            gog_paths.push(path_str);
-                        }
-                    }
-                }
-            }
-        }
-
-        let search_name = search_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("");
-
-        if (search_name == "common" || search_name == "steamapps")
-            && let Ok(entries) = std::fs::read_dir(&search_path)
-        {
-            for entry in entries.flatten() {
-                if let Ok(file_type) = entry.file_type()
-                    && file_type.is_dir()
-                    && let Some(name) = entry.file_name().to_str()
-                    && name.to_uppercase().contains("NWN2")
-                    && is_nwn2_installation(&entry.path())
-                {
-                    let path_str = entry.path().to_string_lossy().to_string();
-                    nwn2_paths.push(path_str.clone());
-                    paths_found += 1;
-
-                    steam_paths.push(path_str);
-                }
-            }
+        let path_lower = path_str.to_lowercase();
+        if path_lower.contains("steam") || path_lower.contains("steamapps") {
+            steam_paths.push(path_str);
+        } else if path_lower.contains("gog") {
+            gog_paths.push(path_str);
         }
     }
 
-    let search_time = search_start.elapsed();
     timing_breakdown.push(PathTiming {
-        operation: "path_discovery".to_string(),
-        duration_ms: search_time.as_millis() as u64,
-        paths_checked,
+        operation: "candidate_validation".to_string(),
+        duration_ms: validation_start.elapsed().as_millis() as u64,
+        paths_checked: candidate_paths.len() as u32,
         paths_found,
     });
-
-    let mut unique_nwn2_paths = Vec::new();
-    let mut seen_paths = std::collections::HashSet::new();
-
-    for path in nwn2_paths {
-        let canonical_path = std::fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(&path));
-        let canonical_str = canonical_path.to_string_lossy().to_string();
-
-        if !seen_paths.contains(&canonical_str) {
-            seen_paths.insert(canonical_str);
-            unique_nwn2_paths.push(path);
-        }
-    }
-
-    let mut unique_steam_paths = Vec::new();
-    let mut seen_steam = std::collections::HashSet::new();
-    for path in steam_paths {
-        let canonical_path = std::fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(&path));
-        let canonical_str = canonical_path.to_string_lossy().to_string();
-        if !seen_steam.contains(&canonical_str) {
-            seen_steam.insert(canonical_str);
-            unique_steam_paths.push(path);
-        }
-    }
-
-    let mut unique_gog_paths = Vec::new();
-    let mut seen_gog = std::collections::HashSet::new();
-    for path in gog_paths {
-        let canonical_path = std::fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(&path));
-        let canonical_str = canonical_path.to_string_lossy().to_string();
-        if !seen_gog.contains(&canonical_str) {
-            seen_gog.insert(canonical_str);
-            unique_gog_paths.push(path);
-        }
-    }
 
     let total_time = start_time.elapsed();
 
     Ok(DiscoveryResult {
-        nwn2_paths: unique_nwn2_paths,
-        steam_paths: unique_steam_paths,
-        gog_paths: unique_gog_paths,
+        nwn2_paths: dedupe_string_paths(nwn2_paths),
+        steam_paths: dedupe_string_paths(steam_paths),
+        gog_paths: dedupe_string_paths(gog_paths),
         total_time_ms: total_time.as_millis() as u64,
         timing_breakdown,
     })
@@ -194,93 +113,327 @@ pub fn profile_path_discovery_rust(iterations: u32) -> Result<HashMap<String, f6
     Ok(results)
 }
 
-fn get_default_search_paths() -> Vec<PathBuf> {
-    let mut paths = Vec::new();
+fn get_default_candidate_paths() -> Vec<PathBuf> {
+    build_candidate_paths_from_roots(get_default_search_roots())
+}
 
-    if let Some(home) = dirs::home_dir() {
-        paths.push(home.join("Documents"));
-        paths.push(home.join("Games"));
+fn build_candidate_paths_from_roots(roots: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut candidates = HashSet::new();
+    let mut steam_roots = HashSet::new();
+    let mut steam_library_roots = HashSet::new();
+
+    for root in roots {
+        add_root_candidates(
+            &root,
+            &mut candidates,
+            &mut steam_roots,
+            &mut steam_library_roots,
+        );
     }
+
+    for steam_root in &steam_roots {
+        add_steam_root_candidates(steam_root, &mut candidates, &mut steam_library_roots);
+    }
+
+    for library_root in &steam_library_roots {
+        add_steam_library_candidates(library_root, &mut candidates);
+    }
+
+    for install_path in get_epic_manifest_install_paths() {
+        candidates.insert(install_path);
+    }
+
+    let mut candidate_paths: Vec<_> = candidates.into_iter().collect();
+    candidate_paths.sort();
+    candidate_paths
+}
+
+fn add_root_candidates(
+    root: &Path,
+    candidates: &mut HashSet<PathBuf>,
+    steam_roots: &mut HashSet<PathBuf>,
+    steam_library_roots: &mut HashSet<PathBuf>,
+) {
+    candidates.insert(root.to_path_buf());
+
+    for subdir in [
+        root.to_path_buf(),
+        root.join("Games"),
+        root.join("Epic Games"),
+        root.join("GOG Games"),
+        root.join("Program Files").join("Epic Games"),
+        root.join("Program Files").join("GOG Games"),
+        root.join("Program Files (x86)").join("Epic Games"),
+        root.join("Program Files (x86)").join("GOG Games"),
+    ] {
+        add_named_install_candidates(&subdir, candidates);
+    }
+
+    for steam_root in [
+        root.to_path_buf(),
+        root.join("Steam"),
+        root.join("SteamLibrary"),
+        root.join("Program Files").join("Steam"),
+        root.join("Program Files (x86)").join("Steam"),
+        root.join(".steam").join("steam"),
+        root.join(".steam").join("root"),
+        root.join(".local").join("share").join("Steam"),
+        root.join("Library")
+            .join("Application Support")
+            .join("Steam"),
+    ] {
+        steam_roots.insert(steam_root.clone());
+        if steam_root.join("steamapps").exists() {
+            steam_library_roots.insert(steam_root);
+        }
+    }
+}
+
+fn add_steam_root_candidates(
+    steam_root: &Path,
+    candidates: &mut HashSet<PathBuf>,
+    steam_library_roots: &mut HashSet<PathBuf>,
+) {
+    if steam_root.join("steamapps").exists() {
+        steam_library_roots.insert(steam_root.to_path_buf());
+    }
+
+    if let Some(parent) = steam_root.parent()
+        && parent.join("SteamLibrary").exists()
+    {
+        steam_library_roots.insert(parent.join("SteamLibrary"));
+    }
+
+    let libraryfolders_path = steam_root.join("steamapps").join("libraryfolders.vdf");
+    for library_root in parse_steam_libraryfolders(&libraryfolders_path) {
+        steam_library_roots.insert(library_root);
+    }
+
+    add_steam_library_candidates(steam_root, candidates);
+}
+
+fn add_steam_library_candidates(library_root: &Path, candidates: &mut HashSet<PathBuf>) {
+    add_named_install_candidates(&library_root.join("steamapps").join("common"), candidates);
+    add_named_install_candidates(&library_root.join("common"), candidates);
+}
+
+fn add_named_install_candidates(base: &Path, candidates: &mut HashSet<PathBuf>) {
+    candidates.insert(base.to_path_buf());
+
+    for folder_name in KNOWN_GAME_FOLDER_NAMES {
+        candidates.insert(base.join(folder_name));
+    }
+}
+
+fn dedupe_string_paths(paths: Vec<String>) -> Vec<String> {
+    let mut unique_paths = Vec::new();
+    let mut seen_paths = HashSet::new();
+
+    for path in paths {
+        let canonical_path = std::fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(&path));
+        let canonical_str = canonical_path.to_string_lossy().to_string();
+
+        if seen_paths.insert(canonical_str) {
+            unique_paths.push(path);
+        }
+    }
+
+    unique_paths
+}
+
+fn get_default_search_roots() -> Vec<PathBuf> {
+    let mut roots = HashSet::new();
 
     #[cfg(target_os = "windows")]
     {
+        for drive_root in get_windows_drive_roots() {
+            roots.insert(drive_root);
+        }
+
         if let Ok(program_files) = std::env::var("ProgramFiles") {
-            let pf = PathBuf::from(program_files);
-            paths.push(pf.clone());
-            paths.push(pf.join("Steam").join("steamapps").join("common"));
-            paths.push(pf.join("GOG Games"));
-        } else {
-            paths.push(PathBuf::from("C:/Program Files"));
-            paths.push(PathBuf::from("C:/Program Files/Steam/steamapps/common"));
-            paths.push(PathBuf::from("C:/Program Files/GOG Games"));
+            roots.insert(PathBuf::from(program_files));
         }
 
         if let Ok(program_files_x86) = std::env::var("ProgramFiles(x86)") {
-            let pf86 = PathBuf::from(program_files_x86);
-            paths.push(pf86.clone());
-            paths.push(pf86.join("Steam").join("steamapps").join("common"));
-            paths.push(pf86.join("GOG Games"));
-        } else {
-            paths.push(PathBuf::from("C:/Program Files (x86)"));
-            paths.push(PathBuf::from(
-                "C:/Program Files (x86)/Steam/steamapps/common",
-            ));
-            paths.push(PathBuf::from("C:/Program Files (x86)/GOG Games"));
-        }
-
-        paths.push(PathBuf::from("C:/GOG Games"));
-
-        if let Some(home) = dirs::home_dir() {
-            paths.push(home.join("Games"));
+            roots.insert(PathBuf::from(program_files_x86));
         }
     }
 
     #[cfg(target_os = "macos")]
     {
+        roots.insert(PathBuf::from("/Applications"));
+
         if let Some(home) = dirs::home_dir() {
-            paths.push(home.clone());
-            paths.push(home.join("Games"));
+            roots.insert(home.join("Applications"));
+            roots.insert(
+                home.join("Library")
+                    .join("Application Support")
+                    .join("Steam"),
+            );
+            roots.insert(home.join("Games"));
         }
-        paths.push(PathBuf::from("/Applications"));
-        paths.push(PathBuf::from("/opt"));
     }
 
     #[cfg(target_os = "linux")]
     {
         if let Some(home) = dirs::home_dir() {
-            paths.push(home.clone());
-            paths.push(
-                home.join(".steam")
-                    .join("steam")
-                    .join("steamapps")
-                    .join("common"),
-            );
-            paths.push(
-                home.join(".local")
-                    .join("share")
-                    .join("Steam")
-                    .join("steamapps")
-                    .join("common"),
-            );
-            paths.push(home.join("Games"));
+            roots.insert(home.join(".steam").join("steam"));
+            roots.insert(home.join(".steam").join("root"));
+            roots.insert(home.join(".local").join("share").join("Steam"));
+            roots.insert(home.join("Games"));
         }
 
-        paths.push(PathBuf::from("/Applications"));
-        paths.push(PathBuf::from("/opt"));
-        paths.push(PathBuf::from("/usr/local/games"));
-
-        if PathBuf::from("/mnt/c").exists() {
-            paths.push(PathBuf::from("/mnt/c/Program Files"));
-            paths.push(PathBuf::from("/mnt/c/Program Files (x86)"));
-            paths.push(PathBuf::from("/mnt/c/Program Files/Steam/steamapps/common"));
-            paths.push(PathBuf::from(
-                "/mnt/c/Program Files (x86)/Steam/steamapps/common",
-            ));
-            paths.push(PathBuf::from("/mnt/c/GOG Games"));
+        for drive_root in get_wsl_windows_drive_roots() {
+            roots.insert(drive_root);
         }
     }
 
-    paths
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        if let Some(home) = dirs::home_dir() {
+            roots.insert(home.join("Games"));
+        }
+    }
+
+    let mut root_paths: Vec<_> = roots.into_iter().collect();
+    root_paths.sort();
+    root_paths
+}
+
+#[cfg(target_os = "windows")]
+fn get_windows_drive_roots() -> Vec<PathBuf> {
+    ('A'..='Z')
+        .map(|drive| PathBuf::from(format!("{drive}:/")))
+        .filter(|path| path.exists())
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn get_wsl_windows_drive_roots() -> Vec<PathBuf> {
+    let mut drive_roots = Vec::new();
+    let mnt_root = PathBuf::from("/mnt");
+
+    if let Ok(entries) = std::fs::read_dir(mnt_root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let is_drive = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    name.len() == 1 && name.chars().all(|ch| ch.is_ascii_alphabetic())
+                });
+
+            if is_drive {
+                drive_roots.push(path);
+            }
+        }
+    }
+
+    drive_roots.sort();
+    drive_roots
+}
+
+fn parse_steam_libraryfolders(vdf_path: &Path) -> Vec<PathBuf> {
+    let Ok(content) = std::fs::read_to_string(vdf_path) else {
+        return Vec::new();
+    };
+
+    let mut libraries = Vec::new();
+
+    for line in content.lines() {
+        let Some(value) = parse_vdf_key_value(line, "path") else {
+            continue;
+        };
+
+        let normalized = value.replace("\\\\", "\\");
+        libraries.push(PathBuf::from(normalized));
+    }
+
+    libraries
+}
+
+fn parse_vdf_key_value(line: &str, key: &str) -> Option<String> {
+    let tokens: Vec<&str> = line.split('"').collect();
+    if tokens.len() >= 4 && tokens[1] == key {
+        return Some(tokens[3].to_string());
+    }
+
+    None
+}
+
+fn get_epic_manifest_install_paths() -> Vec<PathBuf> {
+    let mut install_paths = Vec::new();
+
+    for manifest_dir in epic_manifest_dirs() {
+        let Ok(entries) = std::fs::read_dir(manifest_dir) else {
+            continue;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("item") {
+                continue;
+            }
+
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(manifest) = serde_json::from_str::<Value>(&content) else {
+                continue;
+            };
+            let Some(install_location) = manifest.get("InstallLocation").and_then(Value::as_str)
+            else {
+                continue;
+            };
+
+            install_paths.push(PathBuf::from(install_location));
+        }
+    }
+
+    install_paths
+}
+
+fn epic_manifest_dirs() -> Vec<PathBuf> {
+    let mut manifest_dirs = HashSet::new();
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(program_data) = std::env::var("ProgramData") {
+            manifest_dirs.insert(
+                PathBuf::from(program_data)
+                    .join("Epic")
+                    .join("EpicGamesLauncher")
+                    .join("Data")
+                    .join("Manifests"),
+            );
+        } else {
+            manifest_dirs.insert(
+                PathBuf::from("C:/ProgramData")
+                    .join("Epic")
+                    .join("EpicGamesLauncher")
+                    .join("Data")
+                    .join("Manifests"),
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        for drive_root in get_wsl_windows_drive_roots() {
+            manifest_dirs.insert(
+                drive_root
+                    .join("ProgramData")
+                    .join("Epic")
+                    .join("EpicGamesLauncher")
+                    .join("Data")
+                    .join("Manifests"),
+            );
+        }
+    }
+
+    let mut manifest_paths: Vec<_> = manifest_dirs.into_iter().collect();
+    manifest_paths.sort();
+    manifest_paths
 }
 
 fn is_nwn2_installation(path: &Path) -> bool {
@@ -300,4 +453,61 @@ fn is_nwn2_installation(path: &Path) -> bool {
     }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_candidate_paths_from_roots, parse_steam_libraryfolders};
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_parse_steam_libraryfolders_reads_library_paths() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let steamapps_dir = temp_dir.path().join("steamapps");
+        fs::create_dir_all(&steamapps_dir).expect("steamapps dir");
+
+        let vdf_path = steamapps_dir.join("libraryfolders.vdf");
+        fs::write(
+            &vdf_path,
+            "\"libraryfolders\"\n{\n    \"0\"\n    {\n        \"path\"        \"D:\\\\SteamLibrary\"\n    }\n    \"1\"\n    {\n        \"path\"        \"E:\\\\Games\"\n    }\n}\n",
+        )
+        .expect("write vdf");
+
+        let libraries = parse_steam_libraryfolders(&vdf_path);
+
+        assert_eq!(libraries.len(), 2);
+        assert_eq!(libraries[0], PathBuf::from("D:\\SteamLibrary"));
+        assert_eq!(libraries[1], PathBuf::from("E:\\Games"));
+    }
+
+    #[test]
+    fn test_build_candidate_paths_uses_libraryfolders_without_directory_walk() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let steam_root = temp_dir.path().join("Steam");
+        let steamapps_dir = steam_root.join("steamapps");
+        fs::create_dir_all(&steamapps_dir).expect("steamapps dir");
+
+        let vdf_path = steamapps_dir.join("libraryfolders.vdf");
+        let library_root = temp_dir.path().join("SteamLibrary");
+        fs::write(
+            &vdf_path,
+            format!(
+                "\"libraryfolders\"\n{{\n    \"0\"\n    {{\n        \"path\"        \"{}\"\n    }}\n}}\n",
+                library_root.to_string_lossy().replace('\\', "\\\\")
+            ),
+        )
+        .expect("write vdf");
+
+        let candidates = build_candidate_paths_from_roots(vec![steam_root]);
+        let expected = library_root
+            .join("steamapps")
+            .join("common")
+            .join("NWN2 Enhanced Edition");
+
+        assert!(
+            candidates.contains(&expected),
+            "steam libraryfolders path should produce a direct candidate"
+        );
+    }
 }

--- a/src/components/Dashboard/DashboardPanel.tsx
+++ b/src/components/Dashboard/DashboardPanel.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonGroup, Dialog, DialogBody, DialogFooter, Spinner } from '
 import { useTranslations } from '@/hooks/useTranslations';
 import { useCharacterContext } from '@/contexts/CharacterContext';
 import { useErrorHandler } from '@/hooks/useErrorHandler';
-import { TauriAPI, type SaveFile } from '@/lib/tauri-api';
+import { TauriAPI } from '@/lib/tauri-api';
 import { CharacterAPI, type SaveCharacterOption } from '@/services/characterApi';
 import { T, PATTERN_BG } from '../theme';
 import '../blueprint.css';

--- a/src/components/Dashboard/DashboardPanel.tsx
+++ b/src/components/Dashboard/DashboardPanel.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { Button, Spinner } from '@blueprintjs/core';
+import { Button, ButtonGroup, Dialog, DialogBody, DialogFooter, Spinner } from '@blueprintjs/core';
 import { useTranslations } from '@/hooks/useTranslations';
 import { useCharacterContext } from '@/contexts/CharacterContext';
 import { useErrorHandler } from '@/hooks/useErrorHandler';
 import { TauriAPI, type SaveFile } from '@/lib/tauri-api';
+import { CharacterAPI, type SaveCharacterOption } from '@/services/characterApi';
 import { T, PATTERN_BG } from '../theme';
 import '../blueprint.css';
 import { SaveList } from './SaveList';
@@ -15,20 +16,33 @@ import { SettingsDialog } from '../Settings/SettingsPanel';
 
 export default function DashboardPanel() {
   const t = useTranslations();
-  const { importCharacter } = useCharacterContext();
+  const { character, importCharacter } = useCharacterContext();
   const { handleError } = useErrorHandler();
 
+  const [saveMode, setSaveMode] = useState<'sp' | 'mp'>('sp');
   const [saves, setSaves] = useState<SaveEntryData[]>([]);
   const [savePaths, setSavePaths] = useState<string[]>([]);
+  const [defaultSavePath, setDefaultSavePath] = useState('');
   const [isLoadingSaves, setIsLoadingSaves] = useState(true);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [isImporting, setIsImporting] = useState(false);
+  const [isResolvingSaveCharacters, setIsResolvingSaveCharacters] = useState(false);
+  const [loadedSavePath, setLoadedSavePath] = useState<string | null>(null);
+  const [loadedPlayerIndex, setLoadedPlayerIndex] = useState<number | null>(null);
 
   const [showVaultBrowser, setShowVaultBrowser] = useState(false);
   const [showBackupBrowser, setShowBackupBrowser] = useState(false);
   const [backupPath, setBackupPath] = useState('');
   const [backupRefreshKey, setBackupRefreshKey] = useState(0);
   const [showSettings, setShowSettings] = useState(false);
+  const [showCharacterPicker, setShowCharacterPicker] = useState(false);
+  const [saveCharacters, setSaveCharacters] = useState<SaveCharacterOption[]>([]);
+  const [pendingSaveSelection, setPendingSaveSelection] = useState<{
+    path: string;
+    label: string;
+  } | null>(null);
+
+  const isBusy = isImporting || isResolvingSaveCharacters;
 
   useEffect(() => {
     let cancelled = false;
@@ -36,9 +50,13 @@ export default function DashboardPanel() {
     async function loadSaves() {
       setIsLoadingSaves(true);
       try {
-        const result: SaveFile[] = await TauriAPI.findNWN2Saves();
+        const [result, defaultPath] = await Promise.all([
+          TauriAPI.findNWN2Saves(saveMode),
+          invoke<string>('get_default_saves_path', { saveMode }),
+        ]);
         if (cancelled) return;
 
+        setDefaultSavePath(defaultPath);
         const paths: string[] = [];
         const entries: SaveEntryData[] = result.map(save => {
           paths.push(save.path);
@@ -49,14 +67,14 @@ export default function DashboardPanel() {
               ? new Date(save.modified * 1000).toLocaleString()
               : '',
             thumbnail: null,
-            isActive: false,
+            isActive: save.path === loadedSavePath,
           };
         });
 
         setSaves(entries);
         setSavePaths(paths);
+        setSelectedIndex(null);
 
-        // Load thumbnails in background
         result.forEach((save, i) => {
           if (save.thumbnail) {
             TauriAPI.getSaveThumbnail(save.thumbnail).then(base64 => {
@@ -65,7 +83,7 @@ export default function DashboardPanel() {
                   j === i ? { ...s, thumbnail: base64 } : s
                 ));
               }
-            }).catch(() => { /* thumbnail failed, keep placeholder */ });
+            }).catch(() => {});
           }
         });
       } catch (err) {
@@ -77,16 +95,32 @@ export default function DashboardPanel() {
 
     loadSaves();
     return () => { cancelled = true; };
-  }, [handleError]);
+  }, [handleError, loadedSavePath, saveMode]);
 
-  const handleOpenSave = async () => {
-    if (selectedIndex === null || isImporting) return;
-    const path = savePaths[selectedIndex];
-    if (!path) return;
+  useEffect(() => {
+    if (!character) {
+      setLoadedSavePath(null);
+      setLoadedPlayerIndex(null);
+    }
+  }, [character]);
 
+  const confirmSwitch = async (nextLabel: string) => {
+    if (!character) return true;
+    return TauriAPI.confirmSaveSwitch(character.name || t('character.noCharacter'), nextLabel);
+  };
+
+  const importSaveSelection = async (path: string, label: string, playerIndex?: number) => {
     setIsImporting(true);
     try {
-      await importCharacter(path);
+      await importCharacter(path, playerIndex);
+      setLoadedSavePath(path);
+      setLoadedPlayerIndex(playerIndex ?? 0);
+      setSaves(prev =>
+        prev.map((save, index) => ({ ...save, isActive: savePaths[index] === path })),
+      );
+      setPendingSaveSelection(null);
+      setSaveCharacters([]);
+      setShowCharacterPicker(false);
     } catch (err) {
       handleError(err);
     } finally {
@@ -94,19 +128,45 @@ export default function DashboardPanel() {
     }
   };
 
+  const beginImportFlow = async (path: string, label: string) => {
+    if (isBusy) return;
+
+    setIsResolvingSaveCharacters(true);
+    try {
+      const players = await CharacterAPI.listSaveCharacters(path);
+      if (players.length <= 1) {
+        const nextLabel = players[0]?.name || label;
+        const confirmed = await confirmSwitch(nextLabel);
+        if (!confirmed) return;
+
+        await importSaveSelection(path, label, players[0]?.player_index);
+        return;
+      }
+
+      setPendingSaveSelection({ path, label });
+      setSaveCharacters(players);
+      setShowCharacterPicker(true);
+    } catch (err) {
+      handleError(err);
+    } finally {
+      setIsResolvingSaveCharacters(false);
+    }
+  };
+
+  const handleOpenSave = async () => {
+    if (selectedIndex === null || isBusy) return;
+    const path = savePaths[selectedIndex];
+    if (!path) return;
+
+    await beginImportFlow(path, saves[selectedIndex]?.characterName || saves[selectedIndex]?.folderName || path);
+  };
+
   const handleSelectAndOpen = async (index: number) => {
     setSelectedIndex(index);
     const path = savePaths[index];
     if (!path) return;
 
-    setIsImporting(true);
-    try {
-      await importCharacter(path);
-    } catch (err) {
-      handleError(err);
-    } finally {
-      setIsImporting(false);
-    }
+    await beginImportFlow(path, saves[index]?.characterName || saves[index]?.folderName || path);
   };
 
   const handleImportVaultFile = async (file: FileInfo) => {
@@ -122,14 +182,7 @@ export default function DashboardPanel() {
   };
 
   const handleBrowseFile = async (file: FileInfo) => {
-    setIsImporting(true);
-    try {
-      await importCharacter(file.path);
-    } catch (err) {
-      handleError(err);
-    } finally {
-      setIsImporting(false);
-    }
+    await beginImportFlow(file.path, file.character_name || file.save_name || file.name);
   };
 
   return (
@@ -156,23 +209,45 @@ export default function DashboardPanel() {
         <div style={{
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'flex-end',
+          justifyContent: 'space-between',
           padding: '10px 24px',
           borderBottom: `1px solid ${T.borderLight}`,
         }}>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <ButtonGroup minimal>
+              <Button
+                small
+                active={saveMode === 'sp'}
+                disabled={isBusy}
+                onClick={() => setSaveMode('sp')}
+              >
+                {t('dashboard.singlePlayer')}
+              </Button>
+              <Button
+                small
+                active={saveMode === 'mp'}
+                disabled={isBusy}
+                onClick={() => setSaveMode('mp')}
+              >
+                {t('dashboard.multiplayer')}
+              </Button>
+            </ButtonGroup>
+          </div>
+
           <div style={{ display: 'flex', gap: 4 }}>
             {selectedIndex !== null && (
               <Button
                 small
                 intent="primary"
                 icon="folder-open"
-                loading={isImporting}
+                loading={isBusy}
                 onClick={handleOpenSave}
+                disabled={isBusy}
               >
                 {t('dashboard.openSave')}
               </Button>
             )}
-            <Button minimal small icon="import" onClick={() => setShowVaultBrowser(true)}>
+            <Button minimal small icon="import" onClick={() => setShowVaultBrowser(true)} disabled={isBusy}>
               {t('actions.importCharacter')}
             </Button>
             <Button
@@ -201,7 +276,7 @@ export default function DashboardPanel() {
                   if (path) {
                     setBackupPath(path);
                   }
-                } catch { /* open dialog anyway */ }
+                } catch {}
                 setShowBackupBrowser(true);
               }}
             >
@@ -225,6 +300,7 @@ export default function DashboardPanel() {
               onSelect={setSelectedIndex}
               onDoubleClick={handleSelectAndOpen}
               onBrowseFile={handleBrowseFile}
+              defaultBrowsePath={defaultSavePath}
             />
           )}
         </div>
@@ -249,13 +325,98 @@ export default function DashboardPanel() {
           console.log('Restore backup:', file.path);
           setShowBackupBrowser(false);
         }}
-        onDeleteBackup={async (file) => {
-          console.log('Delete backup:', file.path);
+        onDeleteBackup={async () => {
           setBackupRefreshKey(prev => prev + 1);
         }}
       />
 
       {showSettings && <SettingsDialog isOpen onClose={() => setShowSettings(false)} />}
+
+      <Dialog
+        isOpen={showCharacterPicker}
+        onClose={() => {
+          if (isImporting) return;
+          setShowCharacterPicker(false);
+          setPendingSaveSelection(null);
+          setSaveCharacters([]);
+        }}
+        title={t('dashboard.chooseCharacter')}
+      >
+        <DialogBody>
+          <div style={{ color: T.textMuted, marginBottom: 16, lineHeight: 1.5 }}>
+            {t('dashboard.chooseCharacterHint', {
+              save: pendingSaveSelection?.label || t('dashboard.openSave'),
+            })}
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {saveCharacters.map(player => {
+              const classSummary = player.classes.length > 0
+                ? player.classes.map(entry => `${entry.name} ${entry.level}`).join(' / ')
+                : `Level ${player.total_level}`;
+              const isCurrentSelection =
+                loadedSavePath === pendingSaveSelection?.path &&
+                loadedPlayerIndex === player.player_index;
+
+              return (
+                <button
+                  key={`${pendingSaveSelection?.path ?? 'save'}-${player.player_index}`}
+                  type="button"
+                  disabled={isImporting}
+                  onClick={async () => {
+                    if (!pendingSaveSelection) return;
+                    const confirmed = await confirmSwitch(player.name || pendingSaveSelection.label);
+                    if (!confirmed) return;
+                    await importSaveSelection(
+                      pendingSaveSelection.path,
+                      pendingSaveSelection.label,
+                      player.player_index,
+                    );
+                  }}
+                  style={{
+                    width: '100%',
+                    textAlign: 'left',
+                    padding: '12px 14px',
+                    borderRadius: 8,
+                    border: isCurrentSelection
+                      ? `1px solid ${T.accent}`
+                      : `1px solid ${T.borderLight}`,
+                    background: isCurrentSelection ? 'rgba(160, 82, 45, 0.10)' : T.surfaceAlt,
+                    cursor: isImporting ? 'wait' : 'pointer',
+                  }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+                    <div style={{ minWidth: 0 }}>
+                      <div style={{ fontWeight: 600, color: T.text }}>{player.name}</div>
+                      <div style={{ marginTop: 4, fontSize: 12, color: T.textMuted }}>
+                        {player.race}
+                      </div>
+                      <div style={{ marginTop: 8, fontSize: 12, color: T.textMuted }}>
+                        {classSummary}
+                      </div>
+                    </div>
+                    <div style={{ flexShrink: 0, fontSize: 11, color: T.textMuted }}>
+                      {t('dashboard.playerSlot', { slot: player.player_index + 1 })}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </DialogBody>
+        <DialogFooter
+          actions={(
+            <Button
+              text={t('actions.cancel')}
+              onClick={() => {
+                setShowCharacterPicker(false);
+                setPendingSaveSelection(null);
+                setSaveCharacters([]);
+              }}
+              disabled={isImporting}
+            />
+          )}
+        />
+      </Dialog>
     </div>
   );
 }

--- a/src/components/Dashboard/SaveList.tsx
+++ b/src/components/Dashboard/SaveList.tsx
@@ -14,9 +14,17 @@ interface SaveListProps {
   onSelect: (index: number) => void;
   onDoubleClick?: (index: number) => void;
   onBrowseFile?: (file: FileInfo) => void;
+  defaultBrowsePath?: string;
 }
 
-export function SaveList({ saves, selectedIndex, onSelect, onDoubleClick, onBrowseFile }: SaveListProps) {
+export function SaveList({
+  saves,
+  selectedIndex,
+  onSelect,
+  onDoubleClick,
+  onBrowseFile,
+  defaultBrowsePath,
+}: SaveListProps) {
   const t = useTranslations();
   const [showBrowser, setShowBrowser] = useState(false);
   const [browsePath, setBrowsePath] = useState('');
@@ -61,7 +69,15 @@ export function SaveList({ saves, selectedIndex, onSelect, onDoubleClick, onBrow
             borderBottom: `1px solid ${T.borderLight}`,
           }}
         >
-          <Button minimal icon="folder-open" intent="primary" onClick={() => setShowBrowser(true)}>
+          <Button
+            minimal
+            icon="folder-open"
+            intent="primary"
+            onClick={() => {
+              setBrowsePath(defaultBrowsePath ?? '');
+              setShowBrowser(true);
+            }}
+          >
             {t('dashboard.browse')}
           </Button>
         </div>

--- a/src/contexts/CharacterContext.tsx
+++ b/src/contexts/CharacterContext.tsx
@@ -139,7 +139,7 @@ interface CharacterContextState {
   
   // Actions
   loadCharacter: (characterId: number) => Promise<void>;
-  importCharacter: (savePath: string) => Promise<void>;
+  importCharacter: (savePath: string, playerIndex?: number) => Promise<void>;
   loadSubsystem: (subsystem: SubsystemType, options?: { force?: boolean; silent?: boolean }) => Promise<unknown>;
   updateSubsystem: (subsystem: SubsystemType, data: unknown) => Promise<void>;
   updateSubsystemData: (subsystem: SubsystemType, data: unknown) => void;
@@ -435,13 +435,13 @@ export function CharacterProvider({ children }: { children: ReactNode }) {
   }, [loadMetadataInternal, preloadGameData]);
 
   // Import character from save
-  const importCharacter = useCallback(async (savePath: string) => {
+  const importCharacter = useCallback(async (savePath: string, playerIndex?: number) => {
     setIsLoading(true);
     setError(null);
     
     try {
       // Step 1: Import the save game (creates backend session)
-      const importResponse = await CharacterAPI.importCharacter(savePath);
+      const importResponse = await CharacterAPI.importCharacter(savePath, playerIndex);
       const newCharacterId = importResponse.id;
       
       if (!newCharacterId) {

--- a/src/hooks/useCharacter.ts
+++ b/src/hooks/useCharacter.ts
@@ -6,7 +6,7 @@ interface UseCharacterResult {
   isLoading: boolean;
   error: string | null;
   loadCharacter: (characterId: number) => Promise<void>;
-  importCharacter: (savePath: string) => Promise<void>;
+  importCharacter: (savePath: string, playerIndex?: number) => Promise<void>;
   refreshCharacter: () => Promise<void>;
 }
 
@@ -38,12 +38,12 @@ export function useCharacter(): UseCharacterResult {
     }
   }, []);
 
-  const importCharacter = useCallback(async (savePath: string) => {
+  const importCharacter = useCallback(async (savePath: string, playerIndex?: number) => {
     setIsLoading(true);
     setError(null);
     
     try {
-      const importResult = await CharacterAPI.importCharacter(savePath);
+      const importResult = await CharacterAPI.importCharacter(savePath, playerIndex);
       await loadCharacter(importResult.id);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to import character';

--- a/src/lib/api/character-state.ts
+++ b/src/lib/api/character-state.ts
@@ -123,8 +123,8 @@ export const CharacterStateAPI = {
   /**
    * Load a character from a save file.
    */
-  loadCharacter: (filePath: string) =>
-    invoke<boolean>('load_character', { filePath }),
+  loadCharacter: (filePath: string, playerIndex?: number) =>
+    invoke<boolean>('load_character', { filePath, playerIndex }),
 
   /**
    * Save the current character.

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -10,6 +10,8 @@ export interface SaveFile {
   character_name?: string;
 }
 
+export type SaveMode = 'sp' | 'mp';
+
 // Path Configuration Interfaces
 export interface PathInfo {
   path: string | null;
@@ -54,8 +56,8 @@ export class TauriAPI {
     return await invoke('select_nwn2_directory');
   }
 
-  static async findNWN2Saves(): Promise<SaveFile[]> {
-    return await invoke('find_nwn2_saves');
+  static async findNWN2Saves(saveMode?: SaveMode): Promise<SaveFile[]> {
+    return await invoke('find_nwn2_saves', { saveMode });
   }
 
   static async selectCharacterFile(): Promise<string | null> {
@@ -138,8 +140,8 @@ export class TauriAPI {
     return TauriAPI.selectSaveFile();
   }
   
-  async findNWN2Saves(): Promise<SaveFile[]> {
-    return TauriAPI.findNWN2Saves();
+  async findNWN2Saves(saveMode?: SaveMode): Promise<SaveFile[]> {
+    return TauriAPI.findNWN2Saves(saveMode);
   }
 
   // Window Management
@@ -151,4 +153,3 @@ export class TauriAPI {
     return await invoke('close_settings_window');
   }
 }
-

--- a/src/services/characterApi.ts
+++ b/src/services/characterApi.ts
@@ -89,6 +89,19 @@ export interface SaveResult {
   backup_created: boolean;
 }
 
+export interface SaveCharacterClass {
+  name: string;
+  level: number;
+}
+
+export interface SaveCharacterOption {
+  player_index: number;
+  name: string;
+  race: string;
+  total_level: number;
+  classes: SaveCharacterClass[];
+}
+
 export interface FeatResponse {
   id: number;
   feat_id?: number;
@@ -643,9 +656,18 @@ export class CharacterAPI {
     return [];
   }
 
-  static async importCharacter(savePath: string): Promise<{id: number; name: string}> {
+  static async listSaveCharacters(savePath: string): Promise<SaveCharacterOption[]> {
     try {
-      await invoke('load_character', { filePath: savePath });
+      return await invoke<SaveCharacterOption[]>('list_save_characters', { filePath: savePath });
+    } catch (error) {
+      console.error('Error listing save characters:', error);
+      throw new Error(String(error));
+    }
+  }
+
+  static async importCharacter(savePath: string, playerIndex?: number): Promise<{id: number; name: string}> {
+    try {
+      await invoke('load_character', { filePath: savePath, playerIndex });
       const name = await invoke<string>('get_character_name');
       return {
         id: Date.now(), // Unique session ID to trigger state updates


### PR DESCRIPTION
## What changed

- adds a `Single Player` / `Multiplayer` toggle to the dashboard and loads saves from the matching NWN2 save root
- adds multiplayer character selection before import when a save contains multiple `Mod_PlayerList` entries
- threads `playerIndex` through the Tauri command layer and frontend character import APIs
- adds `list_save_characters` for the dashboard picker
- implements slot-aware save writes so the selected `Mod_PlayerList` entry is updated, while `player.bic` and `playerinfo.bin` are only rewritten for the primary player slot
- broadens NWN2 install discovery to cover Steam libraryfolders, Epic manifests, and WSL-mounted Windows drives
- improves documents/settings detection for WSL-style setups and auto-fills missing documents/workshop paths even when the game path is already known
- refreshes the `ResourceManager` immediately after path changes so game/data lookups stop using stale indexes

## Why

Upstream currently assumes one editable player character per save and a relatively simple local install layout. That breaks down for multiplayer saves with multiple player entries and for mixed Windows/WSL or non-default installs where the editor needs to discover both the correct NWN2 roots and the correct save/documents roots.

## Impact

- multiplayer saves can now be discovered, opened, and edited from the current upstream dashboard architecture
- editing a non-primary multiplayer slot no longer overwrites the primary `player.bic` mirror
- NWN2 game/data/documents detection is more resilient across Steam, Epic, WSL, and custom library layouts
- changing configured paths now updates backend resource resolution immediately instead of requiring a restart to fully take effect

## Validation

- `cargo clippy -- -D warnings` ✅
- `cargo test --lib` ✅
- `npm run test:unit` ✅
- `npm run build` ✅
- `npm run lint` completed with warnings only, `0` errors
- `cargo fmt --check` still wants the repo-wide formatting sweep now split into separate draft PR `#36`
- `cargo test` is still not green on this checkout because the integration suite depends on missing fixture files such as `src-tauri/tests/fixtures/gff/occidiooctavon/occidiooctavon1.bic` and an initialized NWN2 data directory (`PathNotConfigured("NWN2 data directory")`)