### PR TITLE
[codex] Improve NWN2 path detection and live refresh

### DIFF
--- a/src-tauri/src/commands/paths.rs
+++ b/src-tauri/src/commands/paths.rs
@@ -96,6 +96,11 @@ fn build_path_config(paths: &crate::config::NWN2Paths) -> PathConfig {
     }
 }
 
+async fn sync_resource_manager_paths(state: &AppState, snapshot: crate::config::NWN2Paths) {
+    let mut resource_manager = state.resource_manager.write().await;
+    resource_manager.update_paths(snapshot).await;
+}
+
 #[tauri::command]
 #[instrument(name = "get_paths_config", skip(state))]
 pub async fn get_paths_config(state: State<'_, AppState>) -> CommandResult<PathConfig> {
@@ -111,25 +116,29 @@ pub async fn set_game_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Setting game folder to: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths.set_game_folder(&path).map_err(|e| {
-        if e.contains("does not exist") {
-            CommandError::NotFound {
-                item: format!("Path: {path}"),
+        paths.set_game_folder(&path).map_err(|e| {
+            if e.contains("does not exist") {
+                CommandError::NotFound {
+                    item: format!("Path: {path}"),
+                }
+            } else {
+                CommandError::OperationFailed {
+                    operation: "set_game_folder".to_string(),
+                    reason: e,
+                }
             }
-        } else {
-            CommandError::OperationFailed {
-                operation: "set_game_folder".to_string(),
-                reason: e,
-            }
-        }
-    })?;
+        })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("Game folder set to: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -140,25 +149,29 @@ pub async fn set_documents_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Setting documents folder to: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths.set_documents_folder(&path).map_err(|e| {
-        if e.contains("does not exist") {
-            CommandError::NotFound {
-                item: format!("Path: {path}"),
+        paths.set_documents_folder(&path).map_err(|e| {
+            if e.contains("does not exist") {
+                CommandError::NotFound {
+                    item: format!("Path: {path}"),
+                }
+            } else {
+                CommandError::OperationFailed {
+                    operation: "set_documents_folder".to_string(),
+                    reason: e,
+                }
             }
-        } else {
-            CommandError::OperationFailed {
-                operation: "set_documents_folder".to_string(),
-                reason: e,
-            }
-        }
-    })?;
+        })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("Documents folder set to: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -169,25 +182,29 @@ pub async fn set_steam_workshop_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Setting Steam workshop folder to: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths.set_steam_workshop_folder(&path).map_err(|e| {
-        if e.contains("does not exist") {
-            CommandError::NotFound {
-                item: format!("Path: {path}"),
+        paths.set_steam_workshop_folder(&path).map_err(|e| {
+            if e.contains("does not exist") {
+                CommandError::NotFound {
+                    item: format!("Path: {path}"),
+                }
+            } else {
+                CommandError::OperationFailed {
+                    operation: "set_steam_workshop_folder".to_string(),
+                    reason: e,
+                }
             }
-        } else {
-            CommandError::OperationFailed {
-                operation: "set_steam_workshop_folder".to_string(),
-                reason: e,
-            }
-        }
-    })?;
+        })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("Steam workshop folder set to: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -198,25 +215,29 @@ pub async fn add_override_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Adding override folder: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths.add_custom_override_folder(&path).map_err(|e| {
-        if e.contains("does not exist") {
-            CommandError::NotFound {
-                item: format!("Path: {path}"),
+        paths.add_custom_override_folder(&path).map_err(|e| {
+            if e.contains("does not exist") {
+                CommandError::NotFound {
+                    item: format!("Path: {path}"),
+                }
+            } else {
+                CommandError::OperationFailed {
+                    operation: "add_override_folder".to_string(),
+                    reason: e,
+                }
             }
-        } else {
-            CommandError::OperationFailed {
-                operation: "add_override_folder".to_string(),
-                reason: e,
-            }
-        }
-    })?;
+        })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("Override folder added: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -227,19 +248,23 @@ pub async fn remove_override_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Removing override folder: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths
-        .remove_custom_override_folder(&path)
-        .map_err(|e| CommandError::OperationFailed {
-            operation: "remove_override_folder".to_string(),
-            reason: e,
-        })?;
+        paths
+            .remove_custom_override_folder(&path)
+            .map_err(|e| CommandError::OperationFailed {
+                operation: "remove_override_folder".to_string(),
+                reason: e,
+            })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("Override folder removed: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -250,25 +275,29 @@ pub async fn add_hak_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Adding HAK folder: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths.add_custom_hak_folder(&path).map_err(|e| {
-        if e.contains("does not exist") {
-            CommandError::NotFound {
-                item: format!("Path: {path}"),
+        paths.add_custom_hak_folder(&path).map_err(|e| {
+            if e.contains("does not exist") {
+                CommandError::NotFound {
+                    item: format!("Path: {path}"),
+                }
+            } else {
+                CommandError::OperationFailed {
+                    operation: "add_hak_folder".to_string(),
+                    reason: e,
+                }
             }
-        } else {
-            CommandError::OperationFailed {
-                operation: "add_hak_folder".to_string(),
-                reason: e,
-            }
-        }
-    })?;
+        })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("HAK folder added: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -279,19 +308,23 @@ pub async fn remove_hak_folder(
     path: String,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Removing HAK folder: {}", path);
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths
-        .remove_custom_hak_folder(&path)
-        .map_err(|e| CommandError::OperationFailed {
-            operation: "remove_hak_folder".to_string(),
-            reason: e,
-        })?;
+        paths
+            .remove_custom_hak_folder(&path)
+            .map_err(|e| CommandError::OperationFailed {
+                operation: "remove_hak_folder".to_string(),
+                reason: e,
+            })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: format!("HAK folder removed: {path}"),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -299,19 +332,23 @@ pub async fn remove_hak_folder(
 #[instrument(name = "reset_game_folder", skip(state))]
 pub async fn reset_game_folder(state: State<'_, AppState>) -> CommandResult<PathUpdateResponse> {
     debug!("Resetting game folder to auto-detected");
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths
-        .reset_game_folder()
-        .map_err(|e| CommandError::OperationFailed {
-            operation: "reset_game_folder".to_string(),
-            reason: e,
-        })?;
+        paths
+            .reset_game_folder()
+            .map_err(|e| CommandError::OperationFailed {
+                operation: "reset_game_folder".to_string(),
+                reason: e,
+            })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: "Game folder reset to auto-detected".to_string(),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -321,19 +358,23 @@ pub async fn reset_documents_folder(
     state: State<'_, AppState>,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Resetting documents folder to auto-detected");
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths
-        .reset_documents_folder()
-        .map_err(|e| CommandError::OperationFailed {
-            operation: "reset_documents_folder".to_string(),
-            reason: e,
-        })?;
+        paths
+            .reset_documents_folder()
+            .map_err(|e| CommandError::OperationFailed {
+                operation: "reset_documents_folder".to_string(),
+                reason: e,
+            })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: "Documents folder reset to auto-detected".to_string(),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -343,19 +384,23 @@ pub async fn reset_steam_workshop_folder(
     state: State<'_, AppState>,
 ) -> CommandResult<PathUpdateResponse> {
     debug!("Resetting Steam workshop folder to auto-detected");
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    paths
-        .reset_steam_workshop_folder()
-        .map_err(|e| CommandError::OperationFailed {
-            operation: "reset_steam_workshop_folder".to_string(),
-            reason: e,
-        })?;
+        paths
+            .reset_steam_workshop_folder()
+            .map_err(|e| CommandError::OperationFailed {
+                operation: "reset_steam_workshop_folder".to_string(),
+                reason: e,
+            })?;
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
     Ok(PathUpdateResponse {
         success: true,
         message: "Steam workshop folder reset to auto-detected".to_string(),
-        paths: build_path_config(&paths),
+        paths: build_path_config(&snapshot),
     })
 }
 
@@ -371,25 +416,29 @@ pub struct AutoDetectResponse {
 #[instrument(name = "auto_detect_paths", skip(state))]
 pub async fn auto_detect_paths(state: State<'_, AppState>) -> CommandResult<AutoDetectResponse> {
     debug!("Auto-detecting all paths");
-    let mut paths = state.paths.write();
+    let snapshot = {
+        let mut paths = state.paths.write();
 
-    let _ = paths.reset_game_folder();
-    let _ = paths.reset_documents_folder();
-    let _ = paths.reset_steam_workshop_folder();
+        let _ = paths.reset_game_folder();
+        let _ = paths.reset_documents_folder();
+        let _ = paths.reset_steam_workshop_folder();
+        paths.clone()
+    };
+    sync_resource_manager_paths(&state, snapshot.clone()).await;
 
-    let game_installations = paths
+    let game_installations = snapshot
         .game_folder()
         .map(|p| vec![p.to_string_lossy().to_string()])
         .unwrap_or_default();
 
     Ok(AutoDetectResponse {
         game_installations,
-        documents_folder: paths
+        documents_folder: snapshot
             .documents_folder()
             .map(|p| p.to_string_lossy().to_string()),
-        steam_workshop: paths
+        steam_workshop: snapshot
             .steam_workshop_folder()
             .map(|p| p.to_string_lossy().to_string()),
-        current_paths: build_path_config(&paths),
+        current_paths: build_path_config(&snapshot),
     })
 }

--- a/src-tauri/src/config/nwn2_paths.rs
+++ b/src-tauri/src/config/nwn2_paths.rs
@@ -134,39 +134,57 @@ impl NWN2Paths {
             }
         }
 
-        if self.game_folder.is_none() {
-            self.auto_discover();
+        if self.game_folder.is_none()
+            || self.documents_folder.is_none()
+            || self.steam_workshop_folder.is_none()
+        {
+            self.auto_discover_missing();
         }
     }
 
-    #[instrument(name = "NWN2Paths::auto_discover", skip(self))]
-    fn auto_discover(&mut self) {
+    #[instrument(name = "NWN2Paths::auto_discover_missing", skip(self))]
+    fn auto_discover_missing(&mut self) {
+        self.auto_discover_missing_with(Self::find_documents_folder, Self::find_steam_workshop);
+    }
+
+    fn auto_discover_missing_with(
+        &mut self,
+        find_documents_folder: impl FnOnce() -> Option<PathBuf>,
+        find_steam_workshop: impl FnOnce() -> Option<PathBuf>,
+    ) {
         debug!("Auto-discovering NWN2 installation paths");
         if let Ok(result) = discover_nwn2_paths_rust(None) {
             debug!(
                 "Path discovery found {} candidates",
                 result.nwn2_paths.len()
             );
-            for path in &result.nwn2_paths {
-                let path = PathBuf::from(path);
-                if !path.to_string_lossy().contains("Documents")
-                    && !path.to_string_lossy().contains("My Documents")
-                {
-                    self.game_folder = Some(path);
+            if self.game_folder.is_none() {
+                for path in &result.nwn2_paths {
+                    let path = PathBuf::from(path);
+                    if !path.to_string_lossy().contains("Documents")
+                        && !path.to_string_lossy().contains("My Documents")
+                    {
+                        self.game_folder = Some(path);
+                        self.game_folder_source = PathSource::Discovery;
+                        break;
+                    }
+                }
+
+                if self.game_folder.is_none() && !result.nwn2_paths.is_empty() {
+                    self.game_folder = Some(PathBuf::from(&result.nwn2_paths[0]));
                     self.game_folder_source = PathSource::Discovery;
-                    break;
                 }
             }
 
             if self.documents_folder.is_none() {
-                self.documents_folder = Self::find_documents_folder();
+                self.documents_folder = find_documents_folder();
                 if self.documents_folder.is_some() {
                     self.documents_folder_source = PathSource::Discovery;
                 }
             }
 
             if self.steam_workshop_folder.is_none() && !result.steam_paths.is_empty() {
-                self.steam_workshop_folder = Self::find_steam_workshop();
+                self.steam_workshop_folder = find_steam_workshop();
                 if self.steam_workshop_folder.is_some() {
                     self.steam_workshop_folder_source = PathSource::Discovery;
                 }
@@ -175,6 +193,9 @@ impl NWN2Paths {
     }
 
     fn get_config_path() -> Option<PathBuf> {
+        if let Ok(override_path) = std::env::var("NWN2EE_SETTINGS_PATH") {
+            return Some(PathBuf::from(override_path));
+        }
         dirs::data_dir().map(|d| d.join("nwn2_save_editor").join("settings.json"))
     }
 
@@ -248,19 +269,42 @@ impl NWN2Paths {
 
         #[cfg(not(windows))]
         {
-            if let Some(home) = dirs::home_dir() {
-                let docs = home.join("Documents").join("Neverwinter Nights 2");
-                if docs.exists() {
-                    return Some(docs);
-                }
-                let local = home.join(".local/share/Neverwinter Nights 2");
-                if local.exists() {
-                    return Some(local);
+            for candidate in Self::non_windows_documents_candidates() {
+                if candidate.exists() {
+                    return Some(candidate);
                 }
             }
         }
 
         None
+    }
+
+    #[cfg(not(windows))]
+    fn non_windows_documents_candidates() -> Vec<PathBuf> {
+        let mut candidates = Vec::new();
+
+        if let Some(home) = dirs::home_dir() {
+            candidates.push(home.join("Documents").join("Neverwinter Nights 2"));
+            candidates.push(home.join(".local/share/Neverwinter Nights 2"));
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            if let Ok(userprofile) = std::env::var("USERPROFILE")
+                && let Some(wsl_home) = windows_profile_to_wsl_home(&userprofile)
+            {
+                candidates.push(wsl_home.join("Documents").join("Neverwinter Nights 2"));
+                candidates.push(wsl_home.join("My Documents").join("Neverwinter Nights 2"));
+            }
+
+            if let Ok(username) = std::env::var("USER") {
+                let wsl_home = PathBuf::from("/mnt/c/Users").join(username);
+                candidates.push(wsl_home.join("Documents").join("Neverwinter Nights 2"));
+                candidates.push(wsl_home.join("My Documents").join("Neverwinter Nights 2"));
+            }
+        }
+
+        candidates
     }
 
     fn find_steam_workshop() -> Option<PathBuf> {
@@ -314,7 +358,7 @@ impl NWN2Paths {
     pub fn reset_game_folder(&mut self) -> Result<(), String> {
         self.game_folder = None;
         self.game_folder_source = PathSource::Discovery;
-        self.auto_discover();
+        self.auto_discover_missing();
         self.save_settings().map_err(|e| e.to_string())?;
         Ok(())
     }
@@ -606,6 +650,33 @@ impl NWN2Paths {
     }
 }
 
+#[cfg(all(target_os = "linux", not(windows)))]
+fn windows_profile_to_wsl_home(userprofile: &str) -> Option<PathBuf> {
+    let normalized = userprofile.replace('\\', "/");
+    let mut chars = normalized.chars();
+
+    let drive = chars.next()?;
+    if !drive.is_ascii_alphabetic() {
+        return None;
+    }
+    if chars.next()? != ':' {
+        return None;
+    }
+
+    let mut remainder = chars.as_str().trim_start_matches('/').to_string();
+    if remainder.is_empty() {
+        return None;
+    }
+
+    remainder = remainder.trim_end_matches('/').to_string();
+
+    Some(PathBuf::from(format!(
+        "/mnt/{}/{}",
+        drive.to_ascii_lowercase(),
+        remainder
+    )))
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct NWN2PathsConfig {
     game_folder: Option<String>,
@@ -617,4 +688,138 @@ struct NWN2PathsConfig {
     custom_module_folders: Vec<String>,
     #[serde(default)]
     custom_hak_folders: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(all(target_os = "linux", not(windows)))]
+    use super::windows_profile_to_wsl_home;
+    use super::{NWN2Paths, PathSource};
+    use std::path::PathBuf;
+    use std::sync::{LazyLock, Mutex};
+    use tempfile::TempDir;
+
+    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    fn with_test_settings_path<T>(temp_dir: &TempDir, test: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().expect("env mutex poisoned");
+        let settings_path = temp_dir.path().join("settings.json");
+        let old_settings = std::env::var("NWN2EE_SETTINGS_PATH").ok();
+
+        unsafe {
+            std::env::set_var("NWN2EE_SETTINGS_PATH", &settings_path);
+        }
+
+        let result = test();
+
+        unsafe {
+            if let Some(value) = old_settings {
+                std::env::set_var("NWN2EE_SETTINGS_PATH", value);
+            } else {
+                std::env::remove_var("NWN2EE_SETTINGS_PATH");
+            }
+        }
+
+        result
+    }
+
+    fn paths_for_discovery_test(
+        game_folder: Option<PathBuf>,
+        documents_folder: Option<PathBuf>,
+        steam_workshop_folder: Option<PathBuf>,
+    ) -> NWN2Paths {
+        NWN2Paths {
+            game_folder,
+            documents_folder,
+            steam_workshop_folder,
+            game_folder_source: PathSource::Config,
+            documents_folder_source: PathSource::Config,
+            steam_workshop_folder_source: PathSource::Config,
+            custom_override_folders: Vec::new(),
+            custom_module_folders: Vec::new(),
+            custom_hak_folders: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_save_settings_respects_override_path() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+
+        with_test_settings_path(&temp_dir, || {
+            let paths = NWN2Paths::new();
+            paths.save_settings().expect("failed to save settings");
+            assert!(temp_dir.path().join("settings.json").exists());
+        });
+    }
+
+    #[test]
+    fn test_auto_discover_missing_only_fills_blank_fields() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let configured_game = temp_dir.path().join("configured-game");
+        let configured_workshop = temp_dir.path().join("configured-workshop");
+        let discovered_docs = temp_dir
+            .path()
+            .join("discovered-documents")
+            .join("Neverwinter Nights 2");
+
+        let mut paths = paths_for_discovery_test(
+            Some(configured_game.clone()),
+            None,
+            Some(configured_workshop.clone()),
+        );
+        paths.documents_folder_source = PathSource::Discovery;
+
+        paths.auto_discover_missing_with(
+            || Some(discovered_docs.clone()),
+            || Some(temp_dir.path().join("discovered-workshop")),
+        );
+
+        assert_eq!(paths.game_folder(), Some(&configured_game));
+        assert_eq!(paths.documents_folder(), Some(&discovered_docs));
+        assert_eq!(paths.steam_workshop_folder(), Some(&configured_workshop));
+        assert_eq!(paths.game_folder_source(), PathSource::Config);
+        assert_eq!(paths.documents_folder_source(), PathSource::Discovery);
+        assert_eq!(paths.steam_workshop_folder_source(), PathSource::Config);
+    }
+
+    #[test]
+    fn test_auto_discover_missing_never_overwrites_user_configured_documents() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let configured_game = temp_dir.path().join("configured-game");
+        let configured_docs = temp_dir.path().join("configured-documents");
+        let discovered_docs = temp_dir.path().join("discovered-documents");
+
+        let mut paths =
+            paths_for_discovery_test(Some(configured_game), Some(configured_docs.clone()), None);
+
+        paths.auto_discover_missing_with(|| Some(discovered_docs), || None);
+
+        assert_eq!(paths.documents_folder(), Some(&configured_docs));
+        assert_eq!(paths.documents_folder_source(), PathSource::Config);
+    }
+
+    #[cfg(all(target_os = "linux", not(windows)))]
+    #[test]
+    fn test_windows_profile_to_wsl_home_converts_valid_profiles() {
+        assert_eq!(
+            windows_profile_to_wsl_home(r"C:\Users\foo"),
+            Some(PathBuf::from("/mnt/c/Users/foo"))
+        );
+        assert_eq!(
+            windows_profile_to_wsl_home(r"c:\Users\foo"),
+            Some(PathBuf::from("/mnt/c/Users/foo"))
+        );
+        assert_eq!(
+            windows_profile_to_wsl_home("D:/Users/foo"),
+            Some(PathBuf::from("/mnt/d/Users/foo"))
+        );
+    }
+
+    #[cfg(all(target_os = "linux", not(windows)))]
+    #[test]
+    fn test_windows_profile_to_wsl_home_rejects_malformed_profiles() {
+        for malformed in ["", "Users\\foo", "C", "C:", r"C:\", r"1:\Users\foo"] {
+            assert_eq!(windows_profile_to_wsl_home(malformed), None);
+        }
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -291,7 +291,6 @@ pub fn run() {
             crate::commands::paths::reset_game_folder,
             crate::commands::paths::reset_documents_folder,
             crate::commands::paths::reset_steam_workshop_folder,
-            crate::commands::paths::reset_steam_workshop_folder,
             crate::commands::paths::auto_detect_paths,
             // Config
             crate::commands::config::get_app_config,

--- a/src-tauri/src/services/resource_manager/mod.rs
+++ b/src-tauri/src/services/resource_manager/mod.rs
@@ -136,6 +136,34 @@ impl ResourceManager {
         Ok(())
     }
 
+    pub async fn update_paths(&mut self, new_paths: NWN2Paths) {
+        {
+            let mut paths = self.paths.write().await;
+            *paths = new_paths;
+        }
+
+        self.initialized = false;
+        self.template_locations.clear();
+        self.tlk_cache = None;
+        self.custom_tlk_cache = None;
+        self.hak_overrides.clear();
+        self.module_overrides.clear();
+        self.tda_cache.clear();
+        self.current_module = None;
+        self.module_path = None;
+        self.module_info = None;
+        self.current_campaign_id = None;
+        self.current_campaign_folder = None;
+        self.module_cache.clear();
+        self.file_mod_tracker.clear();
+        self.data_zip_paths.clear();
+        self.resource_index.clear();
+        self.icon_file_paths.clear();
+        self.cache_hits.store(0, Ordering::Relaxed);
+        self.cache_misses.store(0, Ordering::Relaxed);
+        *self.zip_reader.lock() = ZipContentReader::new();
+    }
+
     async fn scan_base_game_zips(&mut self) -> ResourceManagerResult<()> {
         let paths = self.paths.read().await;
         let data_dir = paths

--- a/src-tauri/src/utils/path_discovery.rs
+++ b/src-tauri/src/utils/path_discovery.rs
@@ -1,8 +1,15 @@
-use dirs;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
+
+const KNOWN_GAME_FOLDER_NAMES: &[&str] = &[
+    "NWN2 Enhanced Edition",
+    "Neverwinter Nights 2 Enhanced Edition",
+    "Neverwinter Nights 2",
+    "NWN2",
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PathTiming {
@@ -27,143 +34,55 @@ pub fn discover_nwn2_paths_rust(
     let start_time = Instant::now();
     let mut timing_breakdown = Vec::new();
 
+    let candidate_start = Instant::now();
+    let candidate_paths = if let Some(custom_paths) = search_paths {
+        build_candidate_paths_from_roots(custom_paths.into_iter().map(PathBuf::from).collect())
+    } else {
+        get_default_candidate_paths()
+    };
+    timing_breakdown.push(PathTiming {
+        operation: "candidate_collection".to_string(),
+        duration_ms: candidate_start.elapsed().as_millis() as u64,
+        paths_checked: candidate_paths.len() as u32,
+        paths_found: 0,
+    });
+
+    let validation_start = Instant::now();
     let mut nwn2_paths = Vec::new();
     let mut steam_paths = Vec::new();
     let mut gog_paths = Vec::new();
-
-    let paths_to_search = if let Some(custom_paths) = search_paths {
-        custom_paths.into_iter().map(PathBuf::from).collect()
-    } else {
-        get_default_search_paths()
-    };
-
-    let search_start = Instant::now();
-    let mut paths_checked = 0;
     let mut paths_found = 0;
 
-    for search_path in paths_to_search {
-        if !search_path.exists() {
+    for candidate in &candidate_paths {
+        if !candidate.exists() || !is_nwn2_installation(candidate) {
             continue;
         }
 
-        paths_checked += 1;
+        paths_found += 1;
+        let path_str = candidate.to_string_lossy().to_string();
+        nwn2_paths.push(path_str.clone());
 
-        let patterns = ["Neverwinter Nights 2", "NWN2", "nwn2"];
-
-        if is_nwn2_installation(&search_path) {
-            let path_str = search_path.to_string_lossy().to_string();
-            nwn2_paths.push(path_str.clone());
-            paths_found += 1;
-
-            if path_str.contains("Steam") || path_str.contains("steamapps") {
-                steam_paths.push(path_str);
-            } else if path_str.contains("GOG") {
-                gog_paths.push(path_str);
-            }
-        }
-
-        if let Ok(entries) = std::fs::read_dir(&search_path) {
-            for entry in entries.flatten() {
-                if let Ok(file_type) = entry.file_type()
-                    && file_type.is_dir()
-                    && let Some(name) = entry.file_name().to_str()
-                {
-                    let name_lower = name.to_lowercase();
-                    let matches_pattern = patterns.iter().any(|pattern| {
-                        let pattern_lower = pattern.to_lowercase();
-                        name_lower.contains(&pattern_lower)
-                            || name_lower.starts_with(&pattern_lower)
-                    });
-
-                    if matches_pattern && is_nwn2_installation(&entry.path()) {
-                        let path_str = entry.path().to_string_lossy().to_string();
-                        nwn2_paths.push(path_str.clone());
-                        paths_found += 1;
-
-                        if path_str.contains("Steam") || path_str.contains("steamapps") {
-                            steam_paths.push(path_str);
-                        } else if path_str.contains("GOG") {
-                            gog_paths.push(path_str);
-                        }
-                    }
-                }
-            }
-        }
-
-        let search_name = search_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("");
-
-        if (search_name == "common" || search_name == "steamapps")
-            && let Ok(entries) = std::fs::read_dir(&search_path)
-        {
-            for entry in entries.flatten() {
-                if let Ok(file_type) = entry.file_type()
-                    && file_type.is_dir()
-                    && let Some(name) = entry.file_name().to_str()
-                    && name.to_uppercase().contains("NWN2")
-                    && is_nwn2_installation(&entry.path())
-                {
-                    let path_str = entry.path().to_string_lossy().to_string();
-                    nwn2_paths.push(path_str.clone());
-                    paths_found += 1;
-
-                    steam_paths.push(path_str);
-                }
-            }
+        let path_lower = path_str.to_lowercase();
+        if path_lower.contains("steam") || path_lower.contains("steamapps") {
+            steam_paths.push(path_str);
+        } else if path_lower.contains("gog") {
+            gog_paths.push(path_str);
         }
     }
 
-    let search_time = search_start.elapsed();
     timing_breakdown.push(PathTiming {
-        operation: "path_discovery".to_string(),
-        duration_ms: search_time.as_millis() as u64,
-        paths_checked,
+        operation: "candidate_validation".to_string(),
+        duration_ms: validation_start.elapsed().as_millis() as u64,
+        paths_checked: candidate_paths.len() as u32,
         paths_found,
     });
-
-    let mut unique_nwn2_paths = Vec::new();
-    let mut seen_paths = std::collections::HashSet::new();
-
-    for path in nwn2_paths {
-        let canonical_path = std::fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(&path));
-        let canonical_str = canonical_path.to_string_lossy().to_string();
-
-        if !seen_paths.contains(&canonical_str) {
-            seen_paths.insert(canonical_str);
-            unique_nwn2_paths.push(path);
-        }
-    }
-
-    let mut unique_steam_paths = Vec::new();
-    let mut seen_steam = std::collections::HashSet::new();
-    for path in steam_paths {
-        let canonical_path = std::fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(&path));
-        let canonical_str = canonical_path.to_string_lossy().to_string();
-        if !seen_steam.contains(&canonical_str) {
-            seen_steam.insert(canonical_str);
-            unique_steam_paths.push(path);
-        }
-    }
-
-    let mut unique_gog_paths = Vec::new();
-    let mut seen_gog = std::collections::HashSet::new();
-    for path in gog_paths {
-        let canonical_path = std::fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(&path));
-        let canonical_str = canonical_path.to_string_lossy().to_string();
-        if !seen_gog.contains(&canonical_str) {
-            seen_gog.insert(canonical_str);
-            unique_gog_paths.push(path);
-        }
-    }
 
     let total_time = start_time.elapsed();
 
     Ok(DiscoveryResult {
-        nwn2_paths: unique_nwn2_paths,
-        steam_paths: unique_steam_paths,
-        gog_paths: unique_gog_paths,
+        nwn2_paths: dedupe_string_paths(nwn2_paths),
+        steam_paths: dedupe_string_paths(steam_paths),
+        gog_paths: dedupe_string_paths(gog_paths),
         total_time_ms: total_time.as_millis() as u64,
         timing_breakdown,
     })
@@ -194,93 +113,331 @@ pub fn profile_path_discovery_rust(iterations: u32) -> Result<HashMap<String, f6
     Ok(results)
 }
 
-fn get_default_search_paths() -> Vec<PathBuf> {
-    let mut paths = Vec::new();
+fn get_default_candidate_paths() -> Vec<PathBuf> {
+    build_candidate_paths_from_roots(get_default_search_roots())
+}
 
-    if let Some(home) = dirs::home_dir() {
-        paths.push(home.join("Documents"));
-        paths.push(home.join("Games"));
+fn build_candidate_paths_from_roots(roots: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut candidates = HashSet::new();
+    let mut steam_roots = HashSet::new();
+    let mut steam_library_roots = HashSet::new();
+
+    for root in roots {
+        add_root_candidates(
+            &root,
+            &mut candidates,
+            &mut steam_roots,
+            &mut steam_library_roots,
+        );
     }
+
+    for steam_root in &steam_roots {
+        add_steam_root_candidates(steam_root, &mut candidates, &mut steam_library_roots);
+    }
+
+    for library_root in &steam_library_roots {
+        add_steam_library_candidates(library_root, &mut candidates);
+    }
+
+    for install_path in get_epic_manifest_install_paths() {
+        candidates.insert(install_path);
+    }
+
+    let mut candidate_paths: Vec<_> = candidates.into_iter().collect();
+    candidate_paths.sort();
+    candidate_paths
+}
+
+fn add_root_candidates(
+    root: &Path,
+    candidates: &mut HashSet<PathBuf>,
+    steam_roots: &mut HashSet<PathBuf>,
+    steam_library_roots: &mut HashSet<PathBuf>,
+) {
+    candidates.insert(root.to_path_buf());
+
+    for subdir in [
+        root.to_path_buf(),
+        root.join("Games"),
+        root.join("Epic Games"),
+        root.join("GOG Games"),
+        root.join("Program Files").join("Epic Games"),
+        root.join("Program Files").join("GOG Games"),
+        root.join("Program Files (x86)").join("Epic Games"),
+        root.join("Program Files (x86)").join("GOG Games"),
+    ] {
+        add_named_install_candidates(&subdir, candidates);
+    }
+
+    for steam_root in [
+        root.to_path_buf(),
+        root.join("Steam"),
+        root.join("SteamLibrary"),
+        root.join("Program Files").join("Steam"),
+        root.join("Program Files (x86)").join("Steam"),
+        root.join(".steam").join("steam"),
+        root.join(".steam").join("root"),
+        root.join(".local").join("share").join("Steam"),
+        root.join("Library")
+            .join("Application Support")
+            .join("Steam"),
+    ] {
+        steam_roots.insert(steam_root.clone());
+        if steam_root.join("steamapps").exists() {
+            steam_library_roots.insert(steam_root);
+        }
+    }
+}
+
+fn add_steam_root_candidates(
+    steam_root: &Path,
+    candidates: &mut HashSet<PathBuf>,
+    steam_library_roots: &mut HashSet<PathBuf>,
+) {
+    if steam_root.join("steamapps").exists() {
+        steam_library_roots.insert(steam_root.to_path_buf());
+    }
+
+    if let Some(parent) = steam_root.parent()
+        && parent.join("SteamLibrary").exists()
+    {
+        steam_library_roots.insert(parent.join("SteamLibrary"));
+    }
+
+    let libraryfolders_path = steam_root.join("steamapps").join("libraryfolders.vdf");
+    for library_root in parse_steam_libraryfolders(&libraryfolders_path) {
+        steam_library_roots.insert(library_root);
+    }
+
+    add_steam_library_candidates(steam_root, candidates);
+}
+
+fn add_steam_library_candidates(library_root: &Path, candidates: &mut HashSet<PathBuf>) {
+    add_named_install_candidates(&library_root.join("steamapps").join("common"), candidates);
+    add_named_install_candidates(&library_root.join("common"), candidates);
+}
+
+fn add_named_install_candidates(base: &Path, candidates: &mut HashSet<PathBuf>) {
+    candidates.insert(base.to_path_buf());
+
+    for folder_name in KNOWN_GAME_FOLDER_NAMES {
+        candidates.insert(base.join(folder_name));
+    }
+}
+
+fn dedupe_string_paths(paths: Vec<String>) -> Vec<String> {
+    let mut unique_paths = Vec::new();
+    let mut seen_paths = HashSet::new();
+
+    for path in paths {
+        let canonical_path = std::fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(&path));
+        let canonical_str = canonical_path.to_string_lossy().to_string();
+
+        if seen_paths.insert(canonical_str) {
+            unique_paths.push(path);
+        }
+    }
+
+    unique_paths
+}
+
+fn get_default_search_roots() -> Vec<PathBuf> {
+    let mut roots = HashSet::new();
 
     #[cfg(target_os = "windows")]
     {
+        for drive_root in get_windows_drive_roots() {
+            roots.insert(drive_root);
+        }
+
         if let Ok(program_files) = std::env::var("ProgramFiles") {
-            let pf = PathBuf::from(program_files);
-            paths.push(pf.clone());
-            paths.push(pf.join("Steam").join("steamapps").join("common"));
-            paths.push(pf.join("GOG Games"));
-        } else {
-            paths.push(PathBuf::from("C:/Program Files"));
-            paths.push(PathBuf::from("C:/Program Files/Steam/steamapps/common"));
-            paths.push(PathBuf::from("C:/Program Files/GOG Games"));
+            roots.insert(PathBuf::from(program_files));
         }
 
         if let Ok(program_files_x86) = std::env::var("ProgramFiles(x86)") {
-            let pf86 = PathBuf::from(program_files_x86);
-            paths.push(pf86.clone());
-            paths.push(pf86.join("Steam").join("steamapps").join("common"));
-            paths.push(pf86.join("GOG Games"));
-        } else {
-            paths.push(PathBuf::from("C:/Program Files (x86)"));
-            paths.push(PathBuf::from(
-                "C:/Program Files (x86)/Steam/steamapps/common",
-            ));
-            paths.push(PathBuf::from("C:/Program Files (x86)/GOG Games"));
-        }
-
-        paths.push(PathBuf::from("C:/GOG Games"));
-
-        if let Some(home) = dirs::home_dir() {
-            paths.push(home.join("Games"));
+            roots.insert(PathBuf::from(program_files_x86));
         }
     }
 
     #[cfg(target_os = "macos")]
     {
+        roots.insert(PathBuf::from("/Applications"));
+
         if let Some(home) = dirs::home_dir() {
-            paths.push(home.clone());
-            paths.push(home.join("Games"));
+            roots.insert(home.join("Applications"));
+            roots.insert(
+                home.join("Library")
+                    .join("Application Support")
+                    .join("Steam"),
+            );
+            roots.insert(home.join("Games"));
         }
-        paths.push(PathBuf::from("/Applications"));
-        paths.push(PathBuf::from("/opt"));
     }
 
     #[cfg(target_os = "linux")]
     {
         if let Some(home) = dirs::home_dir() {
-            paths.push(home.clone());
-            paths.push(
-                home.join(".steam")
-                    .join("steam")
-                    .join("steamapps")
-                    .join("common"),
-            );
-            paths.push(
-                home.join(".local")
-                    .join("share")
-                    .join("Steam")
-                    .join("steamapps")
-                    .join("common"),
-            );
-            paths.push(home.join("Games"));
+            roots.insert(home.join(".steam").join("steam"));
+            roots.insert(home.join(".steam").join("root"));
+            roots.insert(home.join(".local").join("share").join("Steam"));
+            roots.insert(home.join("Games"));
         }
 
-        paths.push(PathBuf::from("/Applications"));
-        paths.push(PathBuf::from("/opt"));
-        paths.push(PathBuf::from("/usr/local/games"));
-
-        if PathBuf::from("/mnt/c").exists() {
-            paths.push(PathBuf::from("/mnt/c/Program Files"));
-            paths.push(PathBuf::from("/mnt/c/Program Files (x86)"));
-            paths.push(PathBuf::from("/mnt/c/Program Files/Steam/steamapps/common"));
-            paths.push(PathBuf::from(
-                "/mnt/c/Program Files (x86)/Steam/steamapps/common",
-            ));
-            paths.push(PathBuf::from("/mnt/c/GOG Games"));
+        for drive_root in get_wsl_windows_drive_roots() {
+            roots.insert(drive_root);
         }
     }
 
-    paths
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        if let Some(home) = dirs::home_dir() {
+            roots.insert(home.join("Games"));
+        }
+    }
+
+    let mut root_paths: Vec<_> = roots.into_iter().collect();
+    root_paths.sort();
+    root_paths
+}
+
+#[cfg(target_os = "windows")]
+fn get_windows_drive_roots() -> Vec<PathBuf> {
+    ('A'..='Z')
+        .map(|drive| PathBuf::from(format!("{drive}:/")))
+        .filter(|path| path.exists())
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn get_wsl_windows_drive_roots() -> Vec<PathBuf> {
+    let mut drive_roots = Vec::new();
+    let mnt_root = PathBuf::from("/mnt");
+
+    if let Ok(entries) = std::fs::read_dir(mnt_root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let is_drive = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    name.len() == 1 && name.chars().all(|ch| ch.is_ascii_alphabetic())
+                });
+
+            if is_drive {
+                drive_roots.push(path);
+            }
+        }
+    }
+
+    drive_roots.sort();
+    drive_roots
+}
+
+fn parse_steam_libraryfolders(vdf_path: &Path) -> Vec<PathBuf> {
+    let Ok(content) = std::fs::read_to_string(vdf_path) else {
+        return Vec::new();
+    };
+
+    let mut libraries = Vec::new();
+
+    for line in content.lines() {
+        let Some(value) = parse_vdf_key_value(line, "path") else {
+            continue;
+        };
+
+        let normalized = value.replace("\\\\", "\\");
+        libraries.push(PathBuf::from(normalized));
+    }
+
+    libraries
+}
+
+fn parse_vdf_key_value(line: &str, key: &str) -> Option<String> {
+    let tokens: Vec<&str> = line.split('"').collect();
+    if tokens.len() >= 4 && tokens[1] == key {
+        return Some(tokens[3].to_string());
+    }
+
+    None
+}
+
+fn get_epic_manifest_install_paths() -> Vec<PathBuf> {
+    get_epic_manifest_install_paths_from_dirs(epic_manifest_dirs())
+}
+
+fn get_epic_manifest_install_paths_from_dirs(manifest_dirs: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut install_paths = Vec::new();
+
+    for manifest_dir in manifest_dirs {
+        let Ok(entries) = std::fs::read_dir(manifest_dir) else {
+            continue;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("item") {
+                continue;
+            }
+
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(manifest) = serde_json::from_str::<Value>(&content) else {
+                continue;
+            };
+            let Some(install_location) = manifest.get("InstallLocation").and_then(Value::as_str)
+            else {
+                continue;
+            };
+
+            install_paths.push(PathBuf::from(install_location));
+        }
+    }
+
+    install_paths
+}
+
+fn epic_manifest_dirs() -> Vec<PathBuf> {
+    let mut manifest_dirs = HashSet::new();
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(program_data) = std::env::var("ProgramData") {
+            manifest_dirs.insert(
+                PathBuf::from(program_data)
+                    .join("Epic")
+                    .join("EpicGamesLauncher")
+                    .join("Data")
+                    .join("Manifests"),
+            );
+        } else {
+            manifest_dirs.insert(
+                PathBuf::from("C:/ProgramData")
+                    .join("Epic")
+                    .join("EpicGamesLauncher")
+                    .join("Data")
+                    .join("Manifests"),
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        for drive_root in get_wsl_windows_drive_roots() {
+            manifest_dirs.insert(
+                drive_root
+                    .join("ProgramData")
+                    .join("Epic")
+                    .join("EpicGamesLauncher")
+                    .join("Data")
+                    .join("Manifests"),
+            );
+        }
+    }
+
+    let mut manifest_paths: Vec<_> = manifest_dirs.into_iter().collect();
+    manifest_paths.sort();
+    manifest_paths
 }
 
 fn is_nwn2_installation(path: &Path) -> bool {
@@ -300,4 +457,93 @@ fn is_nwn2_installation(path: &Path) -> bool {
     }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_candidate_paths_from_roots, get_epic_manifest_install_paths_from_dirs,
+        parse_steam_libraryfolders,
+    };
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_parse_steam_libraryfolders_reads_library_paths() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let steamapps_dir = temp_dir.path().join("steamapps");
+        fs::create_dir_all(&steamapps_dir).expect("steamapps dir");
+
+        let vdf_path = steamapps_dir.join("libraryfolders.vdf");
+        fs::write(
+            &vdf_path,
+            "\"libraryfolders\"\n{\n    \"0\"\n    {\n        \"path\"        \"D:\\\\SteamLibrary\"\n    }\n    \"1\"\n    {\n        \"path\"        \"E:\\\\Games\"\n    }\n}\n",
+        )
+        .expect("write vdf");
+
+        let libraries = parse_steam_libraryfolders(&vdf_path);
+
+        assert_eq!(libraries.len(), 2);
+        assert_eq!(libraries[0], PathBuf::from("D:\\SteamLibrary"));
+        assert_eq!(libraries[1], PathBuf::from("E:\\Games"));
+    }
+
+    #[test]
+    fn test_build_candidate_paths_uses_libraryfolders_without_directory_walk() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let steam_root = temp_dir.path().join("Steam");
+        let steamapps_dir = steam_root.join("steamapps");
+        fs::create_dir_all(&steamapps_dir).expect("steamapps dir");
+
+        let vdf_path = steamapps_dir.join("libraryfolders.vdf");
+        let library_root = temp_dir.path().join("SteamLibrary");
+        fs::write(
+            &vdf_path,
+            format!(
+                "\"libraryfolders\"\n{{\n    \"0\"\n    {{\n        \"path\"        \"{}\"\n    }}\n}}\n",
+                library_root.to_string_lossy().replace('\\', "\\\\")
+            ),
+        )
+        .expect("write vdf");
+
+        let candidates = build_candidate_paths_from_roots(vec![steam_root]);
+        let expected = library_root
+            .join("steamapps")
+            .join("common")
+            .join("NWN2 Enhanced Edition");
+
+        assert!(
+            candidates.contains(&expected),
+            "steam libraryfolders path should produce a direct candidate"
+        );
+    }
+
+    #[test]
+    fn test_epic_manifest_detection_reads_install_locations() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let manifest_dir = temp_dir.path().join("Manifests");
+        fs::create_dir_all(&manifest_dir).expect("manifest dir");
+
+        let install_path = temp_dir.path().join("Epic Games").join("NWN2EE");
+        fs::write(
+            manifest_dir.join("nwn2ee.item"),
+            serde_json::json!({
+                "AppName": "NWN2EE",
+                "DisplayName": "Neverwinter Nights 2 Enhanced Edition",
+                "InstallLocation": install_path,
+            })
+            .to_string(),
+        )
+        .expect("write manifest");
+        fs::write(
+            manifest_dir.join("ignored.txt"),
+            serde_json::json!({ "InstallLocation": temp_dir.path().join("ignored") }).to_string(),
+        )
+        .expect("write non-item manifest");
+        fs::write(manifest_dir.join("broken.item"), "{not json").expect("write broken manifest");
+
+        let install_paths = get_epic_manifest_install_paths_from_dirs(vec![manifest_dir]);
+
+        assert_eq!(install_paths, vec![install_path]);
+    }
 }


### PR DESCRIPTION
## Intended merge order

1. this PR
2. #38 `[codex] Add multiplayer save support to dashboard flow`

#39 `[codex] Gate fixture-backed integration tests behind a feature` has been merged and this branch is rebased onto the updated `main`.

## What changed

- broadens NWN2 install discovery to cover Steam `libraryfolders.vdf`, Epic manifests, and WSL-mounted Windows drives
- improves documents/settings detection for WSL-style setups
- auto-fills missing documents/workshop paths without overwriting user-configured paths
- refreshes the `ResourceManager` immediately after path changes so game/data lookups stop using stale indexes
- adds regression coverage for missing-field auto-discovery, Windows-profile-to-WSL conversion, and Epic manifest parsing
- drops the old unrelated `mcp_server.rs` clippy cleanup from this branch

## Why

Upstream currently assumes a relatively simple local install layout. That breaks down for mixed Windows/WSL setups, alternate Steam library roots, Epic installs, and cases where the editor needs to discover both the correct NWN2 install roots and the correct documents/save roots.

## Impact

- NWN2 game/data/documents detection is more resilient across Steam, Epic, WSL, and custom library layouts
- changing configured paths now updates backend resource resolution immediately instead of requiring a restart to fully take effect
- user-entered paths are preserved when auto-discovery fills only missing values

## Validation

- `cargo fmt --check` PASS
- `cargo test auto_discover_missing` PASS
- `cargo test windows_profile_to_wsl_home` PASS
- `cargo test epic_manifest_detection` PASS
- `cargo test --lib` PASS: 373 passed; 1 ignored
- `cargo clippy -- -D warnings` PASS
- `git diff --check` PASS
