### PR TITLE
[codex] Add multiplayer save support to dashboard flow

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -10,7 +10,12 @@
     "closeSession": "Close Session",
     "active": "Active",
     "sessionActive": "Session Active: {name}",
-    "openSave": "Open Save"
+    "openSave": "Open Save",
+    "singlePlayer": "Single Player",
+    "multiplayer": "Multiplayer",
+    "chooseCharacter": "Choose Character",
+    "chooseCharacterHint": "{save} contains multiple player characters. Pick the one to edit.",
+    "playerSlot": "Slot {slot}"
   },
   "fileBrowser": {
     "loadSave": "Load Save",

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1,4 +1,8 @@
+use crate::character::Character;
 use crate::commands::{CommandError, CommandResult};
+use crate::loaders::GameData;
+use crate::parsers::gff::GffParser;
+use crate::services::savegame_handler::SaveGameHandler;
 use crate::state::AppState;
 use tauri::{AppHandle, Manager, State};
 use tracing::{error, info, instrument, warn};
@@ -9,14 +13,20 @@ pub async fn load_character(
     state: State<'_, AppState>,
     app: AppHandle,
     file_path: String,
+    player_index: Option<usize>,
 ) -> CommandResult<bool> {
     info!("Load character command invoked");
 
     let mut session = state.session.write();
-    match session.load_character(&file_path) {
+    match session.load_character(&file_path, player_index) {
         Ok(()) => {
             info!("Character loaded successfully via command");
             drop(session);
+            {
+                let game_data = state.game_data.read();
+                let mut session = state.session.write();
+                session.normalize_loaded_skill_points(&game_data);
+            }
             tokio::spawn(async move {
                 let state = app.state::<AppState>();
 
@@ -45,9 +55,102 @@ pub async fn load_character(
         }
         Err(e) => {
             error!("Failed to load character: {}", e);
-            Err(CommandError::CharacterNotFound { path: file_path })
+            Err(CommandError::FileError {
+                message: e,
+                path: Some(file_path),
+            })
         }
     }
+}
+
+#[derive(Clone, serde::Serialize, specta::Type)]
+pub struct SaveCharacterClass {
+    pub name: String,
+    pub level: u8,
+}
+
+#[derive(Clone, serde::Serialize, specta::Type)]
+pub struct SaveCharacterOption {
+    pub player_index: usize,
+    pub name: String,
+    pub race: String,
+    pub total_level: i32,
+    pub classes: Vec<SaveCharacterClass>,
+}
+
+fn summarize_save_character(
+    player_index: usize,
+    character: Character,
+    game_data: &GameData,
+) -> SaveCharacterOption {
+    let name = {
+        let full_name = character.full_name();
+        if full_name.trim().is_empty() {
+            format!("Player {}", player_index + 1)
+        } else {
+            full_name
+        }
+    };
+
+    let classes = character
+        .class_entries()
+        .into_iter()
+        .map(|entry| SaveCharacterClass {
+            name: character.get_class_name(entry.class_id, game_data),
+            level: entry.level.clamp(0, i32::from(u8::MAX)) as u8,
+        })
+        .collect();
+
+    SaveCharacterOption {
+        player_index,
+        name,
+        race: character.race_name(game_data),
+        total_level: character.total_level(),
+        classes,
+    }
+}
+
+#[tauri::command]
+#[instrument(name = "list_save_characters_command", skip(state), fields(file_path = %file_path))]
+pub async fn list_save_characters(
+    state: State<'_, AppState>,
+    file_path: String,
+) -> CommandResult<Vec<SaveCharacterOption>> {
+    let handler = SaveGameHandler::new(&file_path, false, false).map_err(CommandError::from)?;
+    let playerlist_data = handler.extract_player_data().map_err(CommandError::from)?;
+    let gff = GffParser::from_bytes(playerlist_data).map_err(|e| CommandError::ParseError {
+        message: format!("Failed to parse playerlist.ifo: {e}"),
+        context: Some(file_path.clone()),
+    })?;
+
+    let mut player_entries =
+        crate::state::session_state::read_playerlist_entries(gff).map_err(|message| {
+            CommandError::ParseError {
+                message,
+                context: Some(file_path.clone()),
+            }
+        })?;
+
+    if let Ok(Some(player_bic_data)) = handler.extract_player_bic()
+        && let Ok(primary_fields) =
+            crate::state::session_state::read_player_bic_entry(player_bic_data)
+        && let Some(primary_index) = crate::state::session_state::resolve_primary_player_index(
+            &player_entries,
+            Some(&primary_fields),
+        )
+        && let Some(primary_entry) = player_entries.get_mut(primary_index)
+    {
+        *primary_entry = primary_fields;
+    }
+
+    let game_data = state.game_data.read();
+    Ok(player_entries
+        .into_iter()
+        .enumerate()
+        .map(|(player_index, fields)| {
+            summarize_save_character(player_index, Character::from_gff(fields), &game_data)
+        })
+        .collect())
 }
 
 #[tauri::command]
@@ -93,6 +196,7 @@ pub struct SessionInfo {
     pub character_loaded: bool,
     pub file_path: Option<String>,
     pub dirty: bool,
+    pub player_index: Option<usize>,
 }
 
 #[tauri::command]
@@ -105,6 +209,10 @@ pub async fn get_session_info(state: State<'_, AppState>) -> CommandResult<Sessi
             .as_ref()
             .map(|p| p.to_string_lossy().to_string()),
         dirty: session.has_unsaved_changes(),
+        player_index: session
+            .character
+            .as_ref()
+            .map(|_| session.selected_player_index),
     })
 }
 

--- a/src-tauri/src/file_operations.rs
+++ b/src-tauri/src/file_operations.rs
@@ -6,7 +6,25 @@ use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_shell::ShellExt;
 
 use crate::services::playerinfo::PlayerInfo;
+use crate::services::savegame_handler::SaveGameHandler;
 use crate::state::AppState;
+
+fn read_save_character_name(save_path: &std::path::Path) -> Option<String> {
+    if let Ok(handler) = SaveGameHandler::new(save_path, false, false)
+        && let Ok(Some(summary)) = handler.read_character_summary()
+    {
+        let name = [summary.first_name, summary.last_name]
+            .into_iter()
+            .filter(|part| !part.trim().is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        if !name.trim().is_empty() {
+            return Some(name);
+        }
+    }
+
+    PlayerInfo::get_player_name(save_path.join("playerinfo.bin")).ok()
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone, specta::Type)]
 pub struct SaveFile {
@@ -85,7 +103,7 @@ pub async fn select_save_file(app: tauri::AppHandle) -> Result<SaveFile, String>
                 .as_secs() as i64
         });
 
-    let character_name = PlayerInfo::get_player_name(save_path.join("playerinfo.bin")).ok();
+    let character_name = read_save_character_name(&save_path);
 
     Ok(SaveFile {
         path: path_str,
@@ -113,16 +131,24 @@ pub async fn select_nwn2_directory(app: tauri::AppHandle) -> Result<String, Stri
 }
 
 #[tauri::command]
-pub async fn find_nwn2_saves(state: State<'_, AppState>) -> Result<Vec<SaveFile>, String> {
+pub async fn find_nwn2_saves(
+    state: State<'_, AppState>,
+    save_mode: Option<String>,
+) -> Result<Vec<SaveFile>, String> {
     use std::time::Instant;
     let start_time = Instant::now();
     log::info!("[Rust] Finding available NWN2 saves.");
 
-    let saves_path = state
+    let base_saves_path = state
         .paths
         .read()
         .saves()
         .ok_or("Could not determine NWN2 saves path")?;
+    let saves_path = if save_mode.as_deref() == Some("mp") {
+        base_saves_path.join("multiplayer")
+    } else {
+        base_saves_path
+    };
     let mut saves = Vec::new();
 
     let scan_start = Instant::now();
@@ -179,8 +205,7 @@ pub async fn find_nwn2_saves(state: State<'_, AppState>) -> Result<Vec<SaveFile>
                         .as_secs() as i64
                 });
 
-            let character_name =
-                PlayerInfo::get_player_name(entry.path().join("playerinfo.bin")).ok();
+            let character_name = read_save_character_name(&entry.path());
 
             saves.push(SaveFile {
                 name: save_name,
@@ -525,23 +550,7 @@ pub async fn browse_saves(
             .ok()
             .map(|s| s.trim().to_string());
 
-        let playerinfo_path = entry_path.join("playerinfo.bin");
-        let character_name = match PlayerInfo::get_player_name(&playerinfo_path) {
-            Ok(name) => {
-                log::debug!(
-                    "[browse_saves] Parsed character name: {name} from {}",
-                    playerinfo_path.display()
-                );
-                Some(name)
-            }
-            Err(e) => {
-                log::debug!(
-                    "[browse_saves] Failed to parse playerinfo.bin at {}: {e}",
-                    playerinfo_path.display()
-                );
-                None
-            }
-        };
+        let character_name = read_save_character_name(&entry_path);
 
         let thumbnail_path = entry_path.join("screen.tga");
         let thumbnail = if thumbnail_path.exists() {
@@ -589,12 +598,20 @@ pub async fn browse_saves(
 }
 
 #[tauri::command]
-pub async fn get_default_saves_path(state: State<'_, AppState>) -> Result<String, String> {
-    let saves_path = state
+pub async fn get_default_saves_path(
+    state: State<'_, AppState>,
+    save_mode: Option<String>,
+) -> Result<String, String> {
+    let base_saves_path = state
         .paths
         .read()
         .saves()
         .ok_or("Could not determine NWN2 saves path")?;
+    let saves_path = if save_mode.as_deref() == Some("mp") {
+        base_saves_path.join("multiplayer")
+    } else {
+        base_saves_path
+    };
     Ok(saves_path.to_string_lossy().to_string())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -98,6 +98,7 @@ pub fn run() {
             get_default_localvault_path,
             // Session
             crate::commands::session::load_character,
+            crate::commands::session::list_save_characters,
             crate::commands::session::save_character,
             crate::commands::session::close_character,
             crate::commands::session::get_session_info,

--- a/src-tauri/src/services/playerinfo/mod.rs
+++ b/src-tauri/src/services/playerinfo/mod.rs
@@ -384,8 +384,7 @@ fn write_string(writer: &mut impl Write, s: &str) -> PlayerInfoResult<()> {
 
 fn extract_string(fields: &IndexMap<String, GffValue<'_>>, key: &str) -> Option<String> {
     match fields.get(key)? {
-        GffValue::String(s) => Some(s.to_string()),
-        GffValue::ResRef(s) => Some(s.to_string()),
+        GffValue::String(s) | GffValue::ResRef(s) => Some(s.to_string()),
         _ => None,
     }
 }
@@ -464,4 +463,5 @@ mod tests {
 
         assert_eq!(result, "");
     }
+
 }

--- a/src-tauri/src/services/playerinfo/mod.rs
+++ b/src-tauri/src/services/playerinfo/mod.rs
@@ -463,5 +463,4 @@ mod tests {
 
         assert_eq!(result, "");
     }
-
 }

--- a/src-tauri/src/services/savegame_handler/mod.rs
+++ b/src-tauri/src/services/savegame_handler/mod.rs
@@ -330,7 +330,7 @@ impl SaveGameHandler {
     pub fn update_player_complete(
         &mut self,
         playerlist_content: &[u8],
-        playerbic_content: &[u8],
+        playerbic_content: Option<&[u8]>,
         _base_stats: Option<&CharacterStats>,
         _char_summary: Option<&CharacterSummary>,
     ) -> SaveGameResult<()> {
@@ -348,7 +348,7 @@ impl SaveGameHandler {
                 .last_modified_time(*NWN2_DATE_TIME);
 
             let mut playerlist_written = false;
-            let mut playerbic_written = false;
+            let mut playerbic_present = false;
 
             for i in 0..src_archive.len() {
                 let mut src_entry = src_archive.by_index(i)?;
@@ -359,9 +359,15 @@ impl SaveGameHandler {
                     dst_archive.write_all(playerlist_content)?;
                     playerlist_written = true;
                 } else if name == PLAYER_BIC {
+                    playerbic_present = true;
                     dst_archive.start_file(&name, options)?;
-                    dst_archive.write_all(playerbic_content)?;
-                    playerbic_written = true;
+                    if let Some(playerbic_content) = playerbic_content {
+                        dst_archive.write_all(playerbic_content)?;
+                    } else {
+                        let mut buffer = Vec::with_capacity(src_entry.size() as usize);
+                        src_entry.read_to_end(&mut buffer)?;
+                        dst_archive.write_all(&buffer)?;
+                    }
                 } else {
                     dst_archive.start_file(&name, options)?;
                     let mut buffer = Vec::with_capacity(src_entry.size() as usize);
@@ -375,7 +381,7 @@ impl SaveGameHandler {
                 dst_archive.write_all(playerlist_content)?;
             }
 
-            if !playerbic_written {
+            if !playerbic_present && let Some(playerbic_content) = playerbic_content {
                 dst_archive.start_file(PLAYER_BIC, options)?;
                 dst_archive.write_all(playerbic_content)?;
             }

--- a/src-tauri/src/state/session_state.rs
+++ b/src-tauri/src/state/session_state.rs
@@ -7,10 +7,10 @@ use crate::character::{Character, FeatInfo};
 use crate::loaders::GameData;
 use crate::parsers::gff::{GffParser, GffValue, GffWriter};
 use crate::services::campaign::content::{ModuleInfo, ModuleVariables};
+use crate::services::PlayerInfo;
 use crate::services::item_property_decoder::ItemPropertyDecoder;
 use crate::services::resource_manager::ResourceManager;
 use crate::services::savegame_handler::SaveGameHandler;
-use crate::services::PlayerInfo;
 
 pub struct SessionState {
     pub current_file_path: Option<PathBuf>,
@@ -286,7 +286,8 @@ impl SessionState {
             .extract_player_bic()
             .map_err(|e| format!("Failed to extract player.bic: {e}"))?;
         let current_character_fields = character.clone_gff();
-        let player_bic_bytes = serialize_player_bic_bytes(player_bic_data, &current_character_fields)?;
+        let player_bic_bytes =
+            serialize_player_bic_bytes(player_bic_data, &current_character_fields)?;
 
         let first_name = character.first_name();
         let last_name = character.last_name();
@@ -487,9 +488,7 @@ pub(crate) fn resolve_primary_player_index(
         return Some(0);
     }
 
-    let Some(player_bic_fields) = player_bic_fields else {
-        return None;
-    };
+    let player_bic_fields = player_bic_fields?;
 
     let player_bic_name = Character::from_gff(player_bic_fields.clone()).full_name();
     if player_bic_name.trim().is_empty() {

--- a/src-tauri/src/state/session_state.rs
+++ b/src-tauri/src/state/session_state.rs
@@ -1,18 +1,23 @@
-use std::path::PathBuf;
+use indexmap::IndexMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, info, instrument, warn};
 
 use crate::character::{Character, FeatInfo};
+use crate::loaders::GameData;
+use crate::parsers::gff::{GffParser, GffValue, GffWriter};
 use crate::services::campaign::content::{ModuleInfo, ModuleVariables};
+use crate::services::item_property_decoder::ItemPropertyDecoder;
 use crate::services::resource_manager::ResourceManager;
 use crate::services::savegame_handler::SaveGameHandler;
-
-use crate::services::item_property_decoder::ItemPropertyDecoder;
+use crate::services::PlayerInfo;
 
 pub struct SessionState {
     pub current_file_path: Option<PathBuf>,
     pub savegame_handler: Option<SaveGameHandler>,
     pub character: Option<Character>,
+    pub selected_player_index: usize,
+    pub primary_player_index: Option<usize>,
     pub item_property_decoder: ItemPropertyDecoder,
     pub feat_cache: Option<Vec<FeatInfo>>,
     pub module_info_cache: Option<(ModuleInfo, ModuleVariables)>,
@@ -33,6 +38,8 @@ impl SessionState {
             current_file_path: None,
             savegame_handler: None,
             character: None,
+            selected_player_index: 0,
+            primary_player_index: None,
             item_property_decoder,
             feat_cache: None,
             module_info_cache: None,
@@ -40,7 +47,11 @@ impl SessionState {
     }
 
     #[instrument(name = "SessionState::load_character", skip(self), fields(file_path = %file_path))]
-    pub fn load_character(&mut self, file_path: &str) -> Result<(), String> {
+    pub fn load_character(
+        &mut self,
+        file_path: &str,
+        player_index: Option<usize>,
+    ) -> Result<(), String> {
         info!("Loading character from save file");
         let path = PathBuf::from(file_path);
 
@@ -60,37 +71,44 @@ impl SessionState {
         })?;
         info!("playerlist.ifo extracted ({} bytes)", playerlist_data.len());
 
-        debug!("Parsing GFF data");
-        let gff = crate::parsers::gff::GffParser::from_bytes(playerlist_data).map_err(|e| {
+        debug!("Parsing playerlist.ifo GFF data");
+        let gff = GffParser::from_bytes(playerlist_data).map_err(|e| {
             warn!("GFF parse error: {}", e);
             format!("GFF Parse error: {e}")
         })?;
-        debug!("GFF parsed successfully");
+        debug!("playerlist.ifo parsed successfully");
 
-        debug!("Reading playerlist.ifo root struct");
-        let root_fields = gff.read_struct_fields(0).map_err(|e| {
-            warn!("Failed to read root struct: {}", e);
-            format!("Failed to read root struct: {e}")
-        })?;
-
-        debug!("Extracting Mod_PlayerList[0] (character data)");
-        let fields = {
-            use crate::parsers::gff::GffValue;
-            let mod_player_list = root_fields.get("Mod_PlayerList").ok_or_else(|| {
-                warn!("Mod_PlayerList not found in playerlist.ifo");
-                "Mod_PlayerList not found in playerlist.ifo".to_string()
-            })?;
-
-            if let GffValue::List(lazy_structs) = mod_player_list {
-                let first = lazy_structs.first().ok_or_else(|| {
-                    warn!("Mod_PlayerList is empty");
-                    "Mod_PlayerList is empty".to_string()
-                })?;
-                first.force_load()
-            } else {
-                warn!("Mod_PlayerList is not a list");
-                return Err("Mod_PlayerList is not a list".to_string());
+        let player_entries = read_playerlist_entries(gff)?;
+        let player_bic_fields = match handler.extract_player_bic() {
+            Ok(Some(player_bic_data)) => match read_player_bic_entry(player_bic_data) {
+                Ok(fields) => Some(fields),
+                Err(err) => {
+                    warn!("Failed to parse player.bic while loading save: {}", err);
+                    None
+                }
+            },
+            Ok(None) => None,
+            Err(err) => {
+                warn!("Failed to extract player.bic while loading save: {}", err);
+                None
             }
+        };
+        let primary_player_index =
+            resolve_primary_player_index(&player_entries, player_bic_fields.as_ref());
+        let selected_player_index = player_index.unwrap_or(primary_player_index.unwrap_or(0));
+
+        let fields = if primary_player_index == Some(selected_player_index) {
+            if let Some(fields) = player_bic_fields {
+                debug!(
+                    "Using player.bic as authoritative source for playerlist slot {}",
+                    selected_player_index
+                );
+                fields
+            } else {
+                read_playerlist_entry_from_entries(&player_entries, selected_player_index)?
+            }
+        } else {
+            read_playerlist_entry_from_entries(&player_entries, selected_player_index)?
         };
         info!("Character data extracted ({} fields)", fields.len());
 
@@ -106,128 +124,95 @@ impl SessionState {
         self.savegame_handler = Some(handler);
         self.current_file_path = Some(path);
         self.module_info_cache = None;
+        self.selected_player_index = selected_player_index;
+        self.primary_player_index = primary_player_index;
 
         info!("Character loaded successfully");
         Ok(())
     }
 
-    pub fn save_character(&mut self, game_data: &crate::loaders::GameData) -> Result<(), String> {
-        let handler = self
-            .savegame_handler
+    pub fn normalize_loaded_skill_points(&mut self, game_data: &GameData) {
+        let Some(character) = self.character.as_mut() else {
+            return;
+        };
+
+        let summary = character.get_skill_points_summary(game_data);
+        if summary.mismatch == 0 {
+            return;
+        }
+
+        let was_modified = character.is_modified();
+        character.normalize_skill_points(game_data);
+
+        if !was_modified {
+            character.mark_saved();
+        }
+    }
+
+    pub fn save_character(&mut self, game_data: &GameData) -> Result<(), String> {
+        if self.savegame_handler.is_none() {
+            return Err("No active save handler".to_string());
+        }
+        if self.character.is_none() {
+            return Err("No character loaded".to_string());
+        }
+
+        let char_fields = {
+            let character = self.character.as_mut().unwrap();
+            character.normalize_skill_points(game_data);
+            character
+                .recalculate_stats(game_data)
+                .map_err(|e| format!("Failed to recalculate class-derived stats: {e}"))?;
+            character.clone_gff()
+        };
+
+        let (playerlist_data, player_bic_data) = {
+            let handler = self.savegame_handler.as_ref().unwrap();
+            let playerlist_data = handler
+                .extract_player_data()
+                .map_err(|e| format!("Failed to read playerlist.ifo: {e}"))?;
+            let player_bic_data = handler
+                .extract_player_bic()
+                .map_err(|e| format!("Failed to read player.bic: {e}"))?;
+            (playerlist_data, player_bic_data)
+        };
+
+        let playerlist_bytes =
+            serialize_playerlist_bytes(playerlist_data, &char_fields, self.selected_player_index)?;
+        let update_primary_player_files =
+            self.primary_player_index == Some(self.selected_player_index);
+        let player_bic_bytes = if update_primary_player_files {
+            Some(serialize_player_bic_bytes(player_bic_data, &char_fields)?)
+        } else {
+            None
+        };
+
+        self.savegame_handler
             .as_mut()
-            .ok_or("No active save handler")?;
-        let character = self.character.as_ref().ok_or("No character loaded")?;
+            .unwrap()
+            .update_player_complete(&playerlist_bytes, player_bic_bytes.as_deref(), None, None)
+            .map_err(|e| format!("Failed to write save file: {e}"))?;
 
-        if !character.is_modified() {
-            info!("No changes to save");
-            return Ok(());
+        if update_primary_player_files {
+            self.write_playerinfo(game_data)?;
         }
 
-        let char_fields = character.clone_gff();
+        self.character.as_mut().unwrap().mark_saved();
 
-        // Step 1: Build playerlist.ifo
-        let ifo_bytes = Self::build_playerlist_ifo(&char_fields)
-            .map_err(|e| format!("Failed to build playerlist.ifo: {e}"))?;
-
-        // Step 2: Sync player.bic
-        let bic_bytes = Self::build_synced_player_bic(handler, &char_fields)
-            .map_err(|e| format!("Failed to sync player.bic: {e}"))?;
-
-        // Step 3: Sync playerinfo.bin
-        // playerinfo.bin's subrace field is the load-menu display text; NWN2
-        // matches the icon by TLK name, so resolve labels/indices here.
-        let subrace = character.race_display_name(game_data);
-        let alignment_name = character.alignment().alignment_string();
-        let class_entries = character.class_entries();
-        let classes: Vec<(String, u8)> = class_entries
-            .iter()
-            .map(|e| {
-                let name = character.get_class_name(e.class_id, game_data);
-                (name, e.level as u8)
-            })
-            .collect();
-
-        handler
-            .sync_playerinfo_bin(&char_fields, &subrace, &alignment_name, &classes)
-            .map_err(|e| format!("Failed to sync playerinfo.bin: {e}"))?;
-
-        // Step 4: Atomic write of IFO + BIC to zip
-        handler
-            .update_player_complete(&ifo_bytes, &bic_bytes, None, None)
-            .map_err(|e| format!("Failed to write save files: {e}"))?;
-
-        let character = self.character.as_mut().ok_or("No character loaded")?;
-        character.mark_saved();
-
-        info!("Character saved successfully");
-        Ok(())
-    }
-
-    fn build_playerlist_ifo(
-        char_fields: &indexmap::IndexMap<String, crate::parsers::gff::GffValue<'static>>,
-    ) -> Result<Vec<u8>, String> {
-        use crate::parsers::gff::GffValue;
-
-        let mut root = indexmap::IndexMap::new();
-        root.insert(
-            "Mod_PlayerList".to_string(),
-            GffValue::ListOwned(vec![char_fields.clone()]),
+        info!(
+            "Character saved successfully (playerlist={} bytes, player.bic_updated={})",
+            playerlist_bytes.len(),
+            update_primary_player_files
         );
-
-        let mut writer = crate::parsers::gff::GffWriter::new("IFO ", "V3.2");
-        writer
-            .write(root)
-            .map_err(|e| format!("GFF write error: {e}"))
-    }
-
-    fn build_synced_player_bic(
-        handler: &crate::services::savegame_handler::SaveGameHandler,
-        char_fields: &indexmap::IndexMap<String, crate::parsers::gff::GffValue<'static>>,
-    ) -> Result<Vec<u8>, String> {
-        use crate::parsers::gff::{GffParser, GffValue, GffWriter};
-
-        let bic_data = handler
-            .extract_player_bic()
-            .map_err(|e| format!("Failed to extract player.bic: {e}"))?
-            .ok_or("No player.bic found in save")?;
-
-        let bic_gff = GffParser::from_bytes(bic_data)
-            .map_err(|e| format!("Failed to parse player.bic: {e}"))?;
-
-        let bic_fields = bic_gff
-            .read_struct_fields(0)
-            .map_err(|e| format!("Failed to read player.bic fields: {e}"))?;
-
-        let root_struct_id = bic_gff
-            .get_struct_id(0)
-            .map_err(|e| format!("Failed to get BIC root struct_id: {e}"))?;
-
-        // Merge: for each key in BIC, if it exists in char_fields, overwrite it
-        // Preserves BIC-only fields, updates matching fields from character data
-        let mut merged: indexmap::IndexMap<String, GffValue<'static>> = bic_fields
-            .into_iter()
-            .map(|(k, v)| (k, v.force_owned()))
-            .collect();
-
-        for (key, value) in char_fields {
-            if key.starts_with("__") {
-                continue;
-            }
-            if merged.contains_key(key) {
-                merged.insert(key.clone(), value.clone());
-            }
-        }
-
-        let mut writer = GffWriter::new("BIC ", "V3.2");
-        writer
-            .write_with_struct_id(merged, root_struct_id)
-            .map_err(|e| format!("GFF write error for player.bic: {e}"))
+        Ok(())
     }
 
     pub fn close_character(&mut self) {
         self.character = None;
         self.savegame_handler = None;
         self.current_file_path = None;
+        self.selected_player_index = 0;
+        self.primary_player_index = None;
         self.feat_cache = None;
         self.module_info_cache = None;
         crate::services::savegame_handler::backup::clear_backup_tracking();
@@ -255,6 +240,28 @@ impl SessionState {
         self.character.as_mut()
     }
 
+    fn current_save_dir(&self) -> Result<PathBuf, String> {
+        let current_path = self
+            .current_file_path
+            .as_ref()
+            .ok_or("No current save path")?;
+
+        if current_path.is_dir() {
+            Ok(current_path.clone())
+        } else {
+            current_path
+                .parent()
+                .map(PathBuf::from)
+                .ok_or_else(|| "Failed to determine save directory".to_string())
+        }
+    }
+
+    fn write_playerinfo(&self, game_data: &GameData) -> Result<(), String> {
+        let character = self.character.as_ref().ok_or("No character loaded")?;
+        let save_dir = self.current_save_dir()?;
+        write_playerinfo_for_character(&save_dir, character, game_data)
+    }
+
     #[instrument(name = "SessionState::export_to_localvault", skip(self, paths))]
     pub fn export_to_localvault(
         &self,
@@ -277,8 +284,9 @@ impl SessionState {
 
         let player_bic_data = handler
             .extract_player_bic()
-            .map_err(|e| format!("Failed to extract player.bic: {e}"))?
-            .ok_or("No player.bic found in save")?;
+            .map_err(|e| format!("Failed to extract player.bic: {e}"))?;
+        let current_character_fields = character.clone_gff();
+        let player_bic_bytes = serialize_player_bic_bytes(player_bic_data, &current_character_fields)?;
 
         let first_name = character.first_name();
         let last_name = character.last_name();
@@ -295,11 +303,242 @@ impl SessionState {
 
         let dest_path = vault_path.join(&sanitized_filename);
 
-        std::fs::write(&dest_path, &player_bic_data)
+        std::fs::write(&dest_path, &player_bic_bytes)
             .map_err(|e| format!("Failed to write character to vault: {e}"))?;
 
         info!("Exported character to vault: {}", dest_path.display());
 
         Ok(dest_path.to_string_lossy().to_string())
     }
+}
+
+fn write_playerinfo_for_character(
+    save_dir: &Path,
+    character: &Character,
+    game_data: &GameData,
+) -> Result<(), String> {
+    let playerinfo_path = save_dir.join("playerinfo.bin");
+
+    let mut player_info = if playerinfo_path.exists() {
+        PlayerInfo::load(&playerinfo_path)
+            .map_err(|e| format!("Failed to read playerinfo.bin: {e}"))?
+    } else {
+        PlayerInfo::new()
+    };
+
+    let subrace_label = character.subrace_name(game_data).unwrap_or_default();
+    let alignment_name = character.alignment().alignment_string();
+    let classes = character
+        .class_entries()
+        .into_iter()
+        .map(|entry| {
+            let level = entry.level.clamp(0, i32::from(u8::MAX)) as u8;
+            (character.get_class_name(entry.class_id, game_data), level)
+        })
+        .collect::<Vec<_>>();
+
+    player_info.update_from_gff_data(character.gff(), &subrace_label, &alignment_name, &classes);
+    player_info
+        .save(&playerinfo_path)
+        .map_err(|e| format!("Failed to write playerinfo.bin: {e}"))?;
+
+    Ok(())
+}
+
+fn serialize_playerlist_bytes(
+    playerlist_data: Vec<u8>,
+    character_fields: &IndexMap<String, GffValue<'static>>,
+    player_index: usize,
+) -> Result<Vec<u8>, String> {
+    let gff = GffParser::from_bytes(playerlist_data)
+        .map_err(|e| format!("playerlist.ifo parse error: {e}"))?;
+
+    let file_type = gff.file_type.clone();
+    let file_version = gff.file_version.clone();
+
+    let root_fields_raw = gff
+        .read_struct_fields(0)
+        .map_err(|e| format!("Failed to read playerlist.ifo root struct: {e}"))?;
+
+    let mut root_fields: IndexMap<String, GffValue<'static>> = root_fields_raw
+        .into_iter()
+        .map(|(k, v)| (k, v.force_owned()))
+        .collect();
+
+    fn merge_player_entry_fields(
+        existing: &IndexMap<String, GffValue<'static>>,
+        updated_character_fields: &IndexMap<String, GffValue<'static>>,
+    ) -> IndexMap<String, GffValue<'static>> {
+        let mut merged = existing.clone();
+        for (key, value) in updated_character_fields {
+            merged.insert(key.clone(), value.clone());
+        }
+        merged
+    }
+
+    match root_fields.get_mut("Mod_PlayerList") {
+        Some(GffValue::ListOwned(players)) => {
+            if players.is_empty() {
+                if player_index == 0 {
+                    players.push(character_fields.clone());
+                } else {
+                    return Err(format!(
+                        "Selected player index {player_index} is out of range for an empty Mod_PlayerList"
+                    ));
+                }
+            } else {
+                let Some(player_entry) = players.get_mut(player_index) else {
+                    return Err(format!(
+                        "Selected player index {player_index} is out of range for Mod_PlayerList with {} entries",
+                        players.len()
+                    ));
+                };
+                *player_entry = merge_player_entry_fields(player_entry, character_fields);
+            }
+        }
+        Some(_) => {
+            return Err("Mod_PlayerList in playerlist.ifo is not a list".to_string());
+        }
+        None => {
+            if player_index == 0 {
+                root_fields.insert(
+                    "Mod_PlayerList".to_string(),
+                    GffValue::ListOwned(vec![character_fields.clone()]),
+                );
+            } else {
+                return Err(format!(
+                    "Selected player index {player_index} is out of range because Mod_PlayerList is missing"
+                ));
+            }
+        }
+    }
+
+    GffWriter::new(&file_type, &file_version)
+        .write(root_fields)
+        .map_err(|e| format!("playerlist.ifo serialization error: {e}"))
+}
+
+pub(crate) fn read_playerlist_entries(
+    gff: Arc<GffParser>,
+) -> Result<Vec<IndexMap<String, GffValue<'static>>>, String> {
+    debug!("Reading playerlist.ifo root struct");
+    let root_fields = gff.read_struct_fields(0).map_err(|e| {
+        warn!("Failed to read root struct: {}", e);
+        format!("Failed to read root struct: {e}")
+    })?;
+
+    let mod_player_list = root_fields.get("Mod_PlayerList").ok_or_else(|| {
+        warn!("Mod_PlayerList not found in playerlist.ifo");
+        "Mod_PlayerList not found in playerlist.ifo".to_string()
+    })?;
+
+    if let GffValue::List(lazy_structs) = mod_player_list {
+        if lazy_structs.is_empty() {
+            warn!("Mod_PlayerList is empty");
+            return Err("Mod_PlayerList is empty".to_string());
+        }
+
+        Ok(lazy_structs
+            .iter()
+            .map(|entry| entry.force_load())
+            .collect())
+    } else {
+        warn!("Mod_PlayerList is not a list");
+        Err("Mod_PlayerList is not a list".to_string())
+    }
+}
+
+fn read_playerlist_entry_from_entries(
+    entries: &[IndexMap<String, GffValue<'static>>],
+    player_index: usize,
+) -> Result<IndexMap<String, GffValue<'static>>, String> {
+    entries.get(player_index).cloned().ok_or_else(|| {
+        format!(
+            "Selected player index {player_index} is out of range for Mod_PlayerList with {} entries",
+            entries.len()
+        )
+    })
+}
+
+pub(crate) fn read_player_bic_entry(
+    player_bic_data: Vec<u8>,
+) -> Result<IndexMap<String, GffValue<'static>>, String> {
+    let gff = GffParser::from_bytes(player_bic_data).map_err(|e| {
+        warn!("Failed to parse player.bic: {}", e);
+        format!("Failed to parse player.bic: {e}")
+    })?;
+
+    let root_fields = gff.read_struct_fields(0).map_err(|e| {
+        warn!("Failed to read player.bic root struct: {}", e);
+        format!("Failed to read player.bic root struct: {e}")
+    })?;
+
+    Ok(root_fields
+        .into_iter()
+        .map(|(key, value)| (key, value.force_owned()))
+        .collect())
+}
+
+pub(crate) fn resolve_primary_player_index(
+    player_entries: &[IndexMap<String, GffValue<'static>>],
+    player_bic_fields: Option<&IndexMap<String, GffValue<'static>>>,
+) -> Option<usize> {
+    if player_entries.len() == 1 {
+        return Some(0);
+    }
+
+    let Some(player_bic_fields) = player_bic_fields else {
+        return None;
+    };
+
+    let player_bic_name = Character::from_gff(player_bic_fields.clone()).full_name();
+    if player_bic_name.trim().is_empty() {
+        warn!("player.bic has no character name; refusing to infer a primary multiplayer slot");
+        return None;
+    }
+
+    let matching_indices = player_entries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, fields)| {
+            (Character::from_gff(fields.clone()).full_name() == player_bic_name).then_some(index)
+        })
+        .collect::<Vec<_>>();
+
+    match matching_indices.as_slice() {
+        [index] => Some(*index),
+        [] => {
+            warn!(
+                "player.bic name '{}' did not match any Mod_PlayerList entry; refusing to infer a primary multiplayer slot",
+                player_bic_name
+            );
+            None
+        }
+        _ => {
+            warn!(
+                "player.bic name '{}' matched multiple Mod_PlayerList entries; refusing to infer a primary multiplayer slot",
+                player_bic_name
+            );
+            None
+        }
+    }
+}
+
+fn serialize_player_bic_bytes(
+    player_bic_data: Option<Vec<u8>>,
+    character_fields: &IndexMap<String, GffValue<'static>>,
+) -> Result<Vec<u8>, String> {
+    let (file_type, file_version) = if let Some(player_bic_data) = player_bic_data {
+        let gff = GffParser::from_bytes(player_bic_data)
+            .map_err(|e| format!("player.bic parse error: {e}"))?;
+        let file_type = gff.file_type.clone();
+        let file_version = gff.file_version.clone();
+        (file_type, file_version)
+    } else {
+        ("BIC ".to_string(), "V3.2".to_string())
+    };
+
+    GffWriter::new(&file_type, &file_version)
+        .write(character_fields.clone())
+        .map_err(|e| format!("player.bic serialization error: {e}"))
 }

--- a/src-tauri/src/state/session_state.rs
+++ b/src-tauri/src/state/session_state.rs
@@ -6,8 +6,8 @@ use tracing::{debug, info, instrument, warn};
 use crate::character::{Character, FeatInfo};
 use crate::loaders::GameData;
 use crate::parsers::gff::{GffParser, GffValue, GffWriter};
-use crate::services::campaign::content::{ModuleInfo, ModuleVariables};
 use crate::services::PlayerInfo;
+use crate::services::campaign::content::{ModuleInfo, ModuleVariables};
 use crate::services::item_property_decoder::ItemPropertyDecoder;
 use crate::services::resource_manager::ResourceManager;
 use crate::services::savegame_handler::SaveGameHandler;
@@ -284,10 +284,8 @@ impl SessionState {
 
         let player_bic_data = handler
             .extract_player_bic()
-            .map_err(|e| format!("Failed to extract player.bic: {e}"))?;
-        let current_character_fields = character.clone_gff();
-        let player_bic_bytes =
-            serialize_player_bic_bytes(player_bic_data, &current_character_fields)?;
+            .map_err(|e| format!("Failed to extract player.bic: {e}"))?
+            .ok_or("No player.bic found in save")?;
 
         let first_name = character.first_name();
         let last_name = character.last_name();
@@ -304,7 +302,7 @@ impl SessionState {
 
         let dest_path = vault_path.join(&sanitized_filename);
 
-        std::fs::write(&dest_path, &player_bic_bytes)
+        std::fs::write(&dest_path, &player_bic_data)
             .map_err(|e| format!("Failed to write character to vault: {e}"))?;
 
         info!("Exported character to vault: {}", dest_path.display());

--- a/src-tauri/tests/services/savegame_handler.rs
+++ b/src-tauri/tests/services/savegame_handler.rs
@@ -1,8 +1,21 @@
+use app_lib::character::Character;
+use app_lib::parsers::gff::{GffParser, GffValue, GffWriter};
 use app_lib::services::savegame_handler::SaveGameHandler;
+use indexmap::IndexMap;
 use tempfile::TempDir;
 
 #[path = "../common/mod.rs"]
 mod common;
+
+const GARRICK_FULL_NAME: &str = "Garrick Ironheart";
+const TRANSITION_FIELD_NAMES: &[&str] = &[
+    "Race",
+    "Subrace",
+    "ClassList",
+    "LvlStatList",
+    "FeatList",
+    "SkillList",
+];
 
 #[test]
 fn test_savegame_handler_read_operations() {
@@ -99,4 +112,369 @@ fn test_savegame_handler_write_operations() {
         .extract_file("globals.xml")
         .expect("Failed to read modified globals");
     assert_eq!(content_mod, new_globals);
+}
+
+#[test]
+fn test_multiplayer_non_primary_slot_write_preserves_primary_mirrors() {
+    let fixture_path = common::fixtures_path().join("saves/Multiplayer_Slot_Aware");
+    let before_fixture_path = fixture_path.join("before");
+    let after_fixture_path = fixture_path.join("after");
+    if !before_fixture_path.exists() || !after_fixture_path.exists() {
+        eprintln!(
+            "Skipping multiplayer slot-aware write test; before/after fixture pair not found at {}",
+            fixture_path.display()
+        );
+        return;
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    let save_path = temp_dir.path().join("Multiplayer_Slot_Aware_Write");
+    common::copy_dir_recursive(&before_fixture_path, &save_path).expect("Failed to copy fixture");
+
+    let mut handler =
+        SaveGameHandler::new(&save_path, true, false).expect("Failed to create handler");
+    let after_handler = SaveGameHandler::new(&after_fixture_path, true, false)
+        .expect("Failed to create after fixture handler");
+
+    let original_player_bic = handler
+        .extract_player_bic()
+        .expect("Failed to read player.bic")
+        .expect("multiplayer fixture must include player.bic");
+    let playerinfo_path = save_path.join("playerinfo.bin");
+    let original_playerinfo =
+        std::fs::read(&playerinfo_path).expect("multiplayer fixture must include playerinfo.bin");
+
+    let original_playerlist = handler
+        .extract_player_data()
+        .expect("Failed to read playerlist.ifo");
+    let after_playerlist = after_handler
+        .extract_player_data()
+        .expect("Failed to read after fixture playerlist.ifo");
+
+    let original_primary_snapshot = read_transition_snapshot(original_playerlist.clone(), 0);
+    let (player_index, original_slot_fields) =
+        find_player_fields(original_playerlist.clone(), GARRICK_FULL_NAME);
+    assert!(
+        player_index > 0,
+        "fixture must keep Garrick in a non-primary multiplayer slot"
+    );
+
+    let original_slot_snapshot = TransitionSnapshot::from_fields(&original_slot_fields);
+    assert_eq!(
+        original_slot_snapshot.race,
+        Some(31),
+        "before fixture should contain Garrick as Yuan-ti"
+    );
+    assert_eq!(
+        original_slot_snapshot.subrace,
+        Some(47),
+        "before fixture should contain Garrick's Yuan-ti subrace"
+    );
+    assert_eq!(
+        original_slot_snapshot.classes,
+        vec![(0, 5), (4, 2)],
+        "before fixture should contain the known barbarian/fighter split"
+    );
+    assert_eq!(
+        original_slot_snapshot.level_history.len(),
+        7,
+        "before fixture should contain Garrick's known level history"
+    );
+    assert_eq!(
+        original_slot_snapshot.feats.len(),
+        35,
+        "before fixture should contain Garrick's known feat list"
+    );
+    assert_eq!(
+        original_slot_snapshot.skills,
+        vec![(21, 4), (24, 10), (25, 9), (26, 8)],
+        "before fixture should contain Garrick's known skill ranks"
+    );
+    let original_non_transition_snapshot = non_transition_snapshot(&original_slot_fields);
+
+    let (after_player_index, after_slot_fields) =
+        find_player_fields(after_playerlist, GARRICK_FULL_NAME);
+    assert_eq!(
+        after_player_index, player_index,
+        "after fixture should keep Garrick in the same non-primary slot"
+    );
+    let expected_slot_snapshot = TransitionSnapshot::from_fields(&after_slot_fields);
+    assert_eq!(
+        expected_slot_snapshot.race,
+        Some(0),
+        "after fixture should contain Garrick as dwarf"
+    );
+    assert_eq!(
+        expected_slot_snapshot.subrace,
+        Some(2),
+        "after fixture should contain Garrick's dwarf subrace"
+    );
+    assert_eq!(
+        expected_slot_snapshot.classes,
+        vec![(4, 1)],
+        "after fixture should contain the known fighter rebuild"
+    );
+    assert_eq!(
+        expected_slot_snapshot.level_history.len(),
+        1,
+        "after fixture should contain Garrick's rebuilt level history"
+    );
+    assert_eq!(
+        expected_slot_snapshot.feats.len(),
+        25,
+        "after fixture should contain Garrick's rebuilt feat list"
+    );
+    assert_eq!(
+        expected_slot_snapshot.skills,
+        vec![(10, 4), (18, 4), (24, 4)],
+        "after fixture should contain Garrick's rebuilt skill ranks"
+    );
+    assert_ne!(
+        expected_slot_snapshot, original_slot_snapshot,
+        "fixture pair must alter transition-relevant non-primary slot data"
+    );
+
+    let updated_playerlist =
+        playerlist_with_transition_fields(original_playerlist, player_index, &after_slot_fields);
+
+    handler
+        .update_player_complete(&updated_playerlist, None, None, None)
+        .expect("Failed to write non-primary slot playerlist update");
+
+    let reparsed_playerlist = handler
+        .extract_player_data()
+        .expect("Failed to re-read playerlist.ifo");
+    let (_, reparsed_slot_fields) =
+        find_player_fields(reparsed_playerlist.clone(), GARRICK_FULL_NAME);
+    assert_eq!(
+        TransitionSnapshot::from_fields(&reparsed_slot_fields),
+        expected_slot_snapshot,
+        "non-primary slot must match the successful Garrick transition fixture"
+    );
+    assert_eq!(
+        non_transition_snapshot(&reparsed_slot_fields),
+        original_non_transition_snapshot,
+        "non-transition fields, including inventory/items/spells, must stay untouched"
+    );
+    assert_eq!(
+        read_transition_snapshot(reparsed_playerlist, 0),
+        original_primary_snapshot,
+        "editing slot 1+ must not rewrite primary Mod_PlayerList entry"
+    );
+
+    assert_eq!(
+        handler
+            .extract_player_bic()
+            .expect("Failed to re-read player.bic")
+            .expect("player.bic disappeared"),
+        original_player_bic,
+        "non-primary slot writes must not rewrite player.bic"
+    );
+    assert_eq!(
+        std::fs::read(&playerinfo_path).expect("Failed to re-read playerinfo.bin"),
+        original_playerinfo,
+        "non-primary slot writes must not rewrite playerinfo.bin"
+    );
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct TransitionSnapshot {
+    race: Option<i32>,
+    subrace: Option<i32>,
+    classes: Vec<(i32, i32)>,
+    level_history: Vec<String>,
+    feats: Vec<i32>,
+    skills: Vec<(usize, i32)>,
+}
+
+fn playerlist_with_transition_fields(
+    playerlist_data: Vec<u8>,
+    player_index: usize,
+    source_fields: &IndexMap<String, GffValue<'static>>,
+) -> Vec<u8> {
+    let gff = GffParser::from_bytes(playerlist_data).expect("Failed to parse playerlist.ifo");
+    let file_type = gff.file_type.clone();
+    let file_version = gff.file_version.clone();
+    let root_fields_raw = gff
+        .read_struct_fields(0)
+        .expect("Failed to read playerlist root");
+    let mut root_fields = root_fields_raw
+        .into_iter()
+        .map(|(key, value)| (key, value.force_owned()))
+        .collect::<indexmap::IndexMap<_, _>>();
+
+    let players = match root_fields.get_mut("Mod_PlayerList") {
+        Some(GffValue::ListOwned(players)) => players,
+        _ => panic!("Mod_PlayerList must be a list"),
+    };
+    assert!(
+        players.len() > player_index,
+        "multiplayer fixture must contain at least {} player slots",
+        player_index + 1
+    );
+
+    copy_transition_fields(&mut players[player_index], source_fields);
+
+    GffWriter::new(&file_type, &file_version)
+        .write(root_fields)
+        .expect("Failed to serialize updated playerlist")
+}
+
+fn copy_transition_fields(
+    target_fields: &mut IndexMap<String, GffValue<'static>>,
+    source_fields: &IndexMap<String, GffValue<'static>>,
+) {
+    for field_name in TRANSITION_FIELD_NAMES {
+        let value = source_fields
+            .get(*field_name)
+            .unwrap_or_else(|| panic!("after fixture slot must include {field_name}"))
+            .clone()
+            .force_owned();
+        target_fields.insert((*field_name).to_string(), value);
+    }
+}
+
+fn read_transition_snapshot(playerlist_data: Vec<u8>, player_index: usize) -> TransitionSnapshot {
+    let gff = GffParser::from_bytes(playerlist_data).expect("Failed to parse playerlist.ifo");
+    let root_fields = gff
+        .read_struct_fields(0)
+        .expect("Failed to read playerlist root");
+    let players = match root_fields.get("Mod_PlayerList") {
+        Some(GffValue::List(players)) => players,
+        _ => panic!("Mod_PlayerList must be a list"),
+    };
+    let fields = players
+        .get(player_index)
+        .expect("Expected player slot after write")
+        .force_load();
+    TransitionSnapshot::from_fields(&fields)
+}
+
+fn find_player_fields(
+    playerlist_data: Vec<u8>,
+    full_name: &str,
+) -> (usize, IndexMap<String, GffValue<'static>>) {
+    let gff = GffParser::from_bytes(playerlist_data).expect("Failed to parse playerlist.ifo");
+    let root_fields = gff
+        .read_struct_fields(0)
+        .expect("Failed to read playerlist root");
+    let players = match root_fields.get("Mod_PlayerList") {
+        Some(GffValue::List(players)) => players,
+        _ => panic!("Mod_PlayerList must be a list"),
+    };
+
+    players
+        .iter()
+        .enumerate()
+        .find_map(|(index, player)| {
+            let fields = player.force_load();
+            let character = Character::from_gff(fields.clone());
+            (character.full_name() == full_name).then_some((index, fields))
+        })
+        .unwrap_or_else(|| panic!("{full_name} must exist in Mod_PlayerList"))
+}
+
+fn non_transition_snapshot(
+    fields: &IndexMap<String, GffValue<'static>>,
+) -> IndexMap<String, String> {
+    fields
+        .iter()
+        .filter(|(key, _)| !TRANSITION_FIELD_NAMES.contains(&key.as_str()))
+        .map(|(key, value)| (key.clone(), format!("{:?}", value.clone().force_owned())))
+        .collect()
+}
+
+impl TransitionSnapshot {
+    fn from_fields(fields: &IndexMap<String, GffValue<'static>>) -> Self {
+        Self {
+            race: numeric_field(fields, "Race"),
+            subrace: numeric_field(fields, "Subrace"),
+            classes: list_pairs(fields, "ClassList", "Class", "ClassLevel"),
+            level_history: list_entry_snapshots(fields, "LvlStatList"),
+            feats: list_values(fields, "FeatList", "Feat"),
+            skills: skill_ranks(fields),
+        }
+    }
+}
+
+fn list_pairs(
+    fields: &IndexMap<String, GffValue<'static>>,
+    list_name: &str,
+    first_field: &str,
+    second_field: &str,
+) -> Vec<(i32, i32)> {
+    list_entries(fields, list_name)
+        .into_iter()
+        .filter_map(|entry| {
+            Some((
+                numeric_field(&entry, first_field)?,
+                numeric_field(&entry, second_field)?,
+            ))
+        })
+        .collect()
+}
+
+fn list_values(
+    fields: &IndexMap<String, GffValue<'static>>,
+    list_name: &str,
+    field_name: &str,
+) -> Vec<i32> {
+    list_entries(fields, list_name)
+        .into_iter()
+        .filter_map(|entry| numeric_field(&entry, field_name))
+        .collect()
+}
+
+fn list_entry_snapshots(
+    fields: &IndexMap<String, GffValue<'static>>,
+    list_name: &str,
+) -> Vec<String> {
+    list_entries(fields, list_name)
+        .into_iter()
+        .map(|entry| {
+            let owned_entry = entry
+                .into_iter()
+                .map(|(key, value)| (key, value.force_owned()))
+                .collect::<IndexMap<_, _>>();
+            format!("{owned_entry:?}")
+        })
+        .collect()
+}
+
+fn skill_ranks(fields: &IndexMap<String, GffValue<'static>>) -> Vec<(usize, i32)> {
+    list_entries(fields, "SkillList")
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, entry)| {
+            let rank = numeric_field(&entry, "Rank")?;
+            (rank > 0).then_some((index, rank))
+        })
+        .collect()
+}
+
+fn list_entries(
+    fields: &IndexMap<String, GffValue<'static>>,
+    list_name: &str,
+) -> Vec<IndexMap<String, GffValue<'static>>> {
+    match fields.get(list_name) {
+        Some(GffValue::ListOwned(items)) => items.clone(),
+        Some(GffValue::List(items)) => items.iter().map(|item| item.force_load()).collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn numeric_field(fields: &IndexMap<String, GffValue<'static>>, field_name: &str) -> Option<i32> {
+    fields.get(field_name).and_then(value_to_i32)
+}
+
+fn value_to_i32(value: &GffValue<'_>) -> Option<i32> {
+    match value {
+        GffValue::Byte(value) => Some(i32::from(*value)),
+        GffValue::Char(value) => i32::try_from(u32::from(*value)).ok(),
+        GffValue::Word(value) => Some(i32::from(*value)),
+        GffValue::Short(value) => Some(i32::from(*value)),
+        GffValue::Dword(value) => i32::try_from(*value).ok(),
+        GffValue::Int(value) => Some(*value),
+        _ => None,
+    }
 }

--- a/src/components/Dashboard/DashboardPanel.tsx
+++ b/src/components/Dashboard/DashboardPanel.tsx
@@ -7,7 +7,7 @@ import { useTranslations } from '@/hooks/useTranslations';
 import { useCharacterContext } from '@/contexts/CharacterContext';
 import { useErrorHandler } from '@/hooks/useErrorHandler';
 import { useToast } from '@/contexts/ToastContext';
-import { TauriAPI, type SaveFile } from '@/lib/tauri-api';
+import { TauriAPI } from '@/lib/tauri-api';
 import { CharacterAPI, type SaveCharacterOption } from '@/services/characterApi';
 import { T, PATTERN_BG } from '../theme';
 import '../blueprint.css';

--- a/src/components/Dashboard/DashboardPanel.tsx
+++ b/src/components/Dashboard/DashboardPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { Button, Spinner } from '@blueprintjs/core';
+import { Button, ButtonGroup, Dialog, DialogBody, DialogFooter, Spinner } from '@blueprintjs/core';
 import { GiOpenFolder, GiScrollUnfurled, GiBackwardTime, GiCog } from 'react-icons/gi';
 import { GameIcon } from '../shared/GameIcon';
 import { useTranslations } from '@/hooks/useTranslations';
@@ -8,6 +8,7 @@ import { useCharacterContext } from '@/contexts/CharacterContext';
 import { useErrorHandler } from '@/hooks/useErrorHandler';
 import { useToast } from '@/contexts/ToastContext';
 import { TauriAPI, type SaveFile } from '@/lib/tauri-api';
+import { CharacterAPI, type SaveCharacterOption } from '@/services/characterApi';
 import { T, PATTERN_BG } from '../theme';
 import '../blueprint.css';
 import { SaveList } from './SaveList';
@@ -19,21 +20,34 @@ import { BackupAPI } from '@/services/backupApi';
 
 export default function DashboardPanel() {
   const t = useTranslations();
-  const { importCharacter, refreshAll } = useCharacterContext();
+  const { character, importCharacter, refreshAll } = useCharacterContext();
   const { handleError } = useErrorHandler();
   const { showToast } = useToast();
 
+  const [saveMode, setSaveMode] = useState<'sp' | 'mp'>('sp');
   const [saves, setSaves] = useState<SaveEntryData[]>([]);
   const [savePaths, setSavePaths] = useState<string[]>([]);
+  const [defaultSavePath, setDefaultSavePath] = useState('');
   const [isLoadingSaves, setIsLoadingSaves] = useState(true);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [isImporting, setIsImporting] = useState(false);
+  const [isResolvingSaveCharacters, setIsResolvingSaveCharacters] = useState(false);
+  const [loadedSavePath, setLoadedSavePath] = useState<string | null>(null);
+  const [loadedPlayerIndex, setLoadedPlayerIndex] = useState<number | null>(null);
 
   const [showVaultBrowser, setShowVaultBrowser] = useState(false);
   const [showBackupBrowser, setShowBackupBrowser] = useState(false);
   const [backupPath, setBackupPath] = useState('');
   const [backupRefreshKey, setBackupRefreshKey] = useState(0);
   const [showSettings, setShowSettings] = useState(false);
+  const [showCharacterPicker, setShowCharacterPicker] = useState(false);
+  const [saveCharacters, setSaveCharacters] = useState<SaveCharacterOption[]>([]);
+  const [pendingSaveSelection, setPendingSaveSelection] = useState<{
+    path: string;
+    label: string;
+  } | null>(null);
+
+  const isBusy = isImporting || isResolvingSaveCharacters;
 
   useEffect(() => {
     let cancelled = false;
@@ -41,9 +55,13 @@ export default function DashboardPanel() {
     async function loadSaves() {
       setIsLoadingSaves(true);
       try {
-        const result: SaveFile[] = await TauriAPI.findNWN2Saves();
+        const [result, defaultPath] = await Promise.all([
+          TauriAPI.findNWN2Saves(saveMode),
+          invoke<string>('get_default_saves_path', { saveMode }),
+        ]);
         if (cancelled) return;
 
+        setDefaultSavePath(defaultPath);
         const paths: string[] = [];
         const entries: SaveEntryData[] = result.map(save => {
           paths.push(save.path);
@@ -54,14 +72,14 @@ export default function DashboardPanel() {
               ? new Date(save.modified * 1000).toLocaleString()
               : '',
             thumbnail: null,
-            isActive: false,
+            isActive: save.path === loadedSavePath,
           };
         });
 
         setSaves(entries);
         setSavePaths(paths);
+        setSelectedIndex(null);
 
-        // Load thumbnails in background
         result.forEach((save, i) => {
           if (save.thumbnail) {
             TauriAPI.getSaveThumbnail(save.thumbnail).then(base64 => {
@@ -70,7 +88,7 @@ export default function DashboardPanel() {
                   j === i ? { ...s, thumbnail: base64 } : s
                 ));
               }
-            }).catch(() => { /* thumbnail failed, keep placeholder */ });
+            }).catch(() => {});
           }
         });
       } catch (err) {
@@ -82,16 +100,32 @@ export default function DashboardPanel() {
 
     loadSaves();
     return () => { cancelled = true; };
-  }, [handleError]);
+  }, [handleError, loadedSavePath, saveMode]);
 
-  const handleOpenSave = async () => {
-    if (selectedIndex === null || isImporting) return;
-    const path = savePaths[selectedIndex];
-    if (!path) return;
+  useEffect(() => {
+    if (!character) {
+      setLoadedSavePath(null);
+      setLoadedPlayerIndex(null);
+    }
+  }, [character]);
 
+  const confirmSwitch = async (nextLabel: string) => {
+    if (!character) return true;
+    return TauriAPI.confirmSaveSwitch(character.name || t('character.noCharacter'), nextLabel);
+  };
+
+  const importSaveSelection = async (path: string, label: string, playerIndex?: number) => {
     setIsImporting(true);
     try {
-      await importCharacter(path);
+      await importCharacter(path, playerIndex);
+      setLoadedSavePath(path);
+      setLoadedPlayerIndex(playerIndex ?? 0);
+      setSaves(prev =>
+        prev.map((save, index) => ({ ...save, isActive: savePaths[index] === path })),
+      );
+      setPendingSaveSelection(null);
+      setSaveCharacters([]);
+      setShowCharacterPicker(false);
     } catch (err) {
       handleError(err);
     } finally {
@@ -99,19 +133,45 @@ export default function DashboardPanel() {
     }
   };
 
+  const beginImportFlow = async (path: string, label: string) => {
+    if (isBusy) return;
+
+    setIsResolvingSaveCharacters(true);
+    try {
+      const players = await CharacterAPI.listSaveCharacters(path);
+      if (players.length <= 1) {
+        const nextLabel = players[0]?.name || label;
+        const confirmed = await confirmSwitch(nextLabel);
+        if (!confirmed) return;
+
+        await importSaveSelection(path, label, players[0]?.player_index);
+        return;
+      }
+
+      setPendingSaveSelection({ path, label });
+      setSaveCharacters(players);
+      setShowCharacterPicker(true);
+    } catch (err) {
+      handleError(err);
+    } finally {
+      setIsResolvingSaveCharacters(false);
+    }
+  };
+
+  const handleOpenSave = async () => {
+    if (selectedIndex === null || isBusy) return;
+    const path = savePaths[selectedIndex];
+    if (!path) return;
+
+    await beginImportFlow(path, saves[selectedIndex]?.characterName || saves[selectedIndex]?.folderName || path);
+  };
+
   const handleSelectAndOpen = async (index: number) => {
     setSelectedIndex(index);
     const path = savePaths[index];
     if (!path) return;
 
-    setIsImporting(true);
-    try {
-      await importCharacter(path);
-    } catch (err) {
-      handleError(err);
-    } finally {
-      setIsImporting(false);
-    }
+    await beginImportFlow(path, saves[index]?.characterName || saves[index]?.folderName || path);
   };
 
   const handleImportVaultFile = async (file: FileInfo) => {
@@ -127,14 +187,7 @@ export default function DashboardPanel() {
   };
 
   const handleBrowseFile = async (file: FileInfo) => {
-    setIsImporting(true);
-    try {
-      await importCharacter(file.path);
-    } catch (err) {
-      handleError(err);
-    } finally {
-      setIsImporting(false);
-    }
+    await beginImportFlow(file.path, file.character_name || file.save_name || file.name);
   };
 
   return (
@@ -161,23 +214,51 @@ export default function DashboardPanel() {
         <div style={{
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'flex-end',
+          justifyContent: 'space-between',
           padding: '10px 24px',
           borderBottom: `1px solid ${T.borderLight}`,
         }}>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <ButtonGroup minimal>
+              <Button
+                small
+                active={saveMode === 'sp'}
+                disabled={isBusy}
+                onClick={() => setSaveMode('sp')}
+              >
+                {t('dashboard.singlePlayer')}
+              </Button>
+              <Button
+                small
+                active={saveMode === 'mp'}
+                disabled={isBusy}
+                onClick={() => setSaveMode('mp')}
+              >
+                {t('dashboard.multiplayer')}
+              </Button>
+            </ButtonGroup>
+          </div>
+
           <div style={{ display: 'flex', gap: 4 }}>
             {selectedIndex !== null && (
               <Button
                 small
                 intent="primary"
                 icon={<GameIcon icon={GiOpenFolder} size={14} />}
-                loading={isImporting}
+                loading={isBusy}
                 onClick={handleOpenSave}
+                disabled={isBusy}
               >
                 {t('dashboard.openSave')}
               </Button>
             )}
-            <Button minimal small icon={<GameIcon icon={GiScrollUnfurled} size={14} />} onClick={() => setShowVaultBrowser(true)}>
+            <Button
+              minimal
+              small
+              icon={<GameIcon icon={GiScrollUnfurled} size={14} />}
+              onClick={() => setShowVaultBrowser(true)}
+              disabled={isBusy}
+            >
               {t('actions.importCharacter')}
             </Button>
             <Button
@@ -206,7 +287,7 @@ export default function DashboardPanel() {
                   if (path) {
                     setBackupPath(path);
                   }
-                } catch { /* open dialog anyway */ }
+                } catch {}
                 setShowBackupBrowser(true);
               }}
             >
@@ -230,6 +311,7 @@ export default function DashboardPanel() {
               onSelect={setSelectedIndex}
               onDoubleClick={handleSelectAndOpen}
               onBrowseFile={handleBrowseFile}
+              defaultBrowsePath={defaultSavePath}
             />
           )}
         </div>
@@ -276,6 +358,92 @@ export default function DashboardPanel() {
       />
 
       {showSettings && <SettingsDialog isOpen onClose={() => setShowSettings(false)} />}
+
+      <Dialog
+        isOpen={showCharacterPicker}
+        onClose={() => {
+          if (isImporting) return;
+          setShowCharacterPicker(false);
+          setPendingSaveSelection(null);
+          setSaveCharacters([]);
+        }}
+        title={t('dashboard.chooseCharacter')}
+      >
+        <DialogBody>
+          <div style={{ color: T.textMuted, marginBottom: 16, lineHeight: 1.5 }}>
+            {t('dashboard.chooseCharacterHint', {
+              save: pendingSaveSelection?.label || t('dashboard.openSave'),
+            })}
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {saveCharacters.map(player => {
+              const classSummary = player.classes.length > 0
+                ? player.classes.map(entry => `${entry.name} ${entry.level}`).join(' / ')
+                : `Level ${player.total_level}`;
+              const isCurrentSelection =
+                loadedSavePath === pendingSaveSelection?.path &&
+                loadedPlayerIndex === player.player_index;
+
+              return (
+                <button
+                  key={`${pendingSaveSelection?.path ?? 'save'}-${player.player_index}`}
+                  type="button"
+                  disabled={isImporting}
+                  onClick={async () => {
+                    if (!pendingSaveSelection) return;
+                    const confirmed = await confirmSwitch(player.name || pendingSaveSelection.label);
+                    if (!confirmed) return;
+                    await importSaveSelection(
+                      pendingSaveSelection.path,
+                      pendingSaveSelection.label,
+                      player.player_index,
+                    );
+                  }}
+                  style={{
+                    width: '100%',
+                    textAlign: 'left',
+                    padding: '12px 14px',
+                    borderRadius: 8,
+                    border: isCurrentSelection
+                      ? `1px solid ${T.accent}`
+                      : `1px solid ${T.borderLight}`,
+                    background: isCurrentSelection ? 'rgba(160, 82, 45, 0.10)' : T.surfaceAlt,
+                    cursor: isImporting ? 'wait' : 'pointer',
+                  }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+                    <div style={{ minWidth: 0 }}>
+                      <div style={{ fontWeight: 600, color: T.text }}>{player.name}</div>
+                      <div style={{ marginTop: 4, fontSize: 12, color: T.textMuted }}>
+                        {player.race}
+                      </div>
+                      <div style={{ marginTop: 8, fontSize: 12, color: T.textMuted }}>
+                        {classSummary}
+                      </div>
+                    </div>
+                    <div style={{ flexShrink: 0, fontSize: 11, color: T.textMuted }}>
+                      {t('dashboard.playerSlot', { slot: player.player_index + 1 })}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </DialogBody>
+        <DialogFooter
+          actions={(
+            <Button
+              text={t('actions.cancel')}
+              onClick={() => {
+                setShowCharacterPicker(false);
+                setPendingSaveSelection(null);
+                setSaveCharacters([]);
+              }}
+              disabled={isImporting}
+            />
+          )}
+        />
+      </Dialog>
     </div>
   );
 }

--- a/src/components/Dashboard/SaveList.tsx
+++ b/src/components/Dashboard/SaveList.tsx
@@ -16,9 +16,17 @@ interface SaveListProps {
   onSelect: (index: number) => void;
   onDoubleClick?: (index: number) => void;
   onBrowseFile?: (file: FileInfo) => void;
+  defaultBrowsePath?: string;
 }
 
-export function SaveList({ saves, selectedIndex, onSelect, onDoubleClick, onBrowseFile }: SaveListProps) {
+export function SaveList({
+  saves,
+  selectedIndex,
+  onSelect,
+  onDoubleClick,
+  onBrowseFile,
+  defaultBrowsePath,
+}: SaveListProps) {
   const t = useTranslations();
   const [showBrowser, setShowBrowser] = useState(false);
   const [browsePath, setBrowsePath] = useState('');
@@ -63,7 +71,15 @@ export function SaveList({ saves, selectedIndex, onSelect, onDoubleClick, onBrow
             borderBottom: `1px solid ${T.borderLight}`,
           }}
         >
-          <Button minimal icon={<GameIcon icon={GiOpenFolder} size={16} />} intent="primary" onClick={() => setShowBrowser(true)}>
+          <Button
+            minimal
+            icon={<GameIcon icon={GiOpenFolder} size={16} />}
+            intent="primary"
+            onClick={() => {
+              setBrowsePath(defaultBrowsePath ?? '');
+              setShowBrowser(true);
+            }}
+          >
             {t('dashboard.browse')}
           </Button>
         </div>

--- a/src/contexts/CharacterContext.tsx
+++ b/src/contexts/CharacterContext.tsx
@@ -149,7 +149,7 @@ interface CharacterContextState {
   
   // Actions
   loadCharacter: (characterId: number) => Promise<void>;
-  importCharacter: (savePath: string) => Promise<void>;
+  importCharacter: (savePath: string, playerIndex?: number) => Promise<void>;
   loadSubsystem: (subsystem: SubsystemType, options?: { force?: boolean; silent?: boolean }) => Promise<unknown>;
   updateSubsystem: (subsystem: SubsystemType, data: unknown) => Promise<void>;
   updateSubsystemData: (subsystem: SubsystemType, data: unknown) => void;
@@ -455,13 +455,13 @@ export function CharacterProvider({ children }: { children: ReactNode }) {
   }, [loadMetadataInternal, preloadGameData]);
 
   // Import character from save
-  const importCharacter = useCallback(async (savePath: string) => {
+  const importCharacter = useCallback(async (savePath: string, playerIndex?: number) => {
     setIsLoading(true);
     setError(null);
     
     try {
       // Step 1: Import the save game (creates backend session)
-      const importResponse = await CharacterAPI.importCharacter(savePath);
+      const importResponse = await CharacterAPI.importCharacter(savePath, playerIndex);
       const newCharacterId = importResponse.id;
       
       if (!newCharacterId) {

--- a/src/hooks/useCharacter.ts
+++ b/src/hooks/useCharacter.ts
@@ -6,7 +6,7 @@ interface UseCharacterResult {
   isLoading: boolean;
   error: string | null;
   loadCharacter: (characterId: number) => Promise<void>;
-  importCharacter: (savePath: string) => Promise<void>;
+  importCharacter: (savePath: string, playerIndex?: number) => Promise<void>;
   refreshCharacter: () => Promise<void>;
 }
 
@@ -38,12 +38,12 @@ export function useCharacter(): UseCharacterResult {
     }
   }, []);
 
-  const importCharacter = useCallback(async (savePath: string) => {
+  const importCharacter = useCallback(async (savePath: string, playerIndex?: number) => {
     setIsLoading(true);
     setError(null);
     
     try {
-      const importResult = await CharacterAPI.importCharacter(savePath);
+      const importResult = await CharacterAPI.importCharacter(savePath, playerIndex);
       await loadCharacter(importResult.id);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to import character';

--- a/src/lib/api/character-state.ts
+++ b/src/lib/api/character-state.ts
@@ -152,8 +152,8 @@ export const CharacterStateAPI = {
   /**
    * Load a character from a save file.
    */
-  loadCharacter: (filePath: string) =>
-    invoke<boolean>('load_character', { filePath }),
+  loadCharacter: (filePath: string, playerIndex?: number) =>
+    invoke<boolean>('load_character', { filePath, playerIndex }),
 
   /**
    * Save the current character.

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -10,6 +10,8 @@ export interface SaveFile {
   character_name?: string;
 }
 
+export type SaveMode = 'sp' | 'mp';
+
 // Path Configuration Interfaces
 export interface PathInfo {
   path: string | null;
@@ -54,8 +56,8 @@ export class TauriAPI {
     return await invoke('select_nwn2_directory');
   }
 
-  static async findNWN2Saves(): Promise<SaveFile[]> {
-    return await invoke('find_nwn2_saves');
+  static async findNWN2Saves(saveMode?: SaveMode): Promise<SaveFile[]> {
+    return await invoke('find_nwn2_saves', { saveMode });
   }
 
   static async selectCharacterFile(): Promise<string | null> {
@@ -138,8 +140,8 @@ export class TauriAPI {
     return TauriAPI.selectSaveFile();
   }
   
-  async findNWN2Saves(): Promise<SaveFile[]> {
-    return TauriAPI.findNWN2Saves();
+  async findNWN2Saves(saveMode?: SaveMode): Promise<SaveFile[]> {
+    return TauriAPI.findNWN2Saves(saveMode);
   }
 
   // Window Management
@@ -151,4 +153,3 @@ export class TauriAPI {
     return await invoke('close_settings_window');
   }
 }
-

--- a/src/services/characterApi.ts
+++ b/src/services/characterApi.ts
@@ -89,6 +89,19 @@ export interface SaveResult {
   backup_created: boolean;
 }
 
+export interface SaveCharacterClass {
+  name: string;
+  level: number;
+}
+
+export interface SaveCharacterOption {
+  player_index: number;
+  name: string;
+  race: string;
+  total_level: number;
+  classes: SaveCharacterClass[];
+}
+
 export interface FeatResponse {
   id: number;
   feat_id?: number;
@@ -647,9 +660,18 @@ export class CharacterAPI {
     return [];
   }
 
-  static async importCharacter(savePath: string): Promise<{id: number; name: string}> {
+  static async listSaveCharacters(savePath: string): Promise<SaveCharacterOption[]> {
     try {
-      await invoke('load_character', { filePath: savePath });
+      return await invoke<SaveCharacterOption[]>('list_save_characters', { filePath: savePath });
+    } catch (error) {
+      console.error('Error listing save characters:', error);
+      throw new Error(String(error));
+    }
+  }
+
+  static async importCharacter(savePath: string, playerIndex?: number): Promise<{id: number; name: string}> {
+    try {
+      await invoke('load_character', { filePath: savePath, playerIndex });
       const name = await invoke<string>('get_character_name');
       return {
         id: Date.now(), // Unique session ID to trigger state updates


### PR DESCRIPTION
## Current state

#37 and #39 have been merged. This branch is now rebased onto the updated `main` at `adaf433` and the PR head is `48f0a80`.

## What changed

- adds a `Single Player` / `Multiplayer` toggle to the dashboard and loads saves from the matching NWN2 save root
- adds multiplayer character selection before import when a save contains multiple `Mod_PlayerList` entries
- threads `playerIndex` through the Tauri command layer and frontend character import APIs
- adds `list_save_characters` for the dashboard picker
- implements slot-aware save writes so the selected `Mod_PlayerList` entry is updated, while `player.bic` and `playerinfo.bin` are only rewritten for the primary player slot
- adds a fixture-backed regression test for non-primary multiplayer slot writes preserving the primary mirrors
- removes the previous localvault export scope creep so export continues to write the original `player.bic`

## Why

Upstream currently assumes one editable player character per save. Multiplayer saves break that assumption because a single save can contain multiple `Mod_PlayerList` entries, and only the primary player should continue to drive the `player.bic` mirror.

## Impact

- multiplayer saves can now be discovered, opened, and edited from the current upstream dashboard architecture
- editing a non-primary multiplayer slot no longer overwrites the primary `player.bic` mirror
- singleplayer dashboard flow stays intact while multiplayer becomes an explicit mode instead of an implicit edge case

## Validation

- `cargo fmt --check` PASS
- `cargo test` PASS: 373 passed; 1 ignored
- `cargo test --features integration-tests --test services test_multiplayer_non_primary_slot_write_preserves_primary_mirrors -- --nocapture` PASS with the local Garrick before/after fixture pair
- extra local control against newer MP save `000064 - 12-04-2026-21-18` PASS: Garrick is still dwarf/fighter, `playerlist.ifo` and `player.bic` transition snapshots match for the primary slot, and `playerinfo.bin` reports `Shield Dwarf`, `Fighter 13`; it differs from `000040` only by expected later progression in slot/levels/feats/skills
- `cargo clippy -- -D warnings` PASS
- `git diff --check` PASS
- `npm run lint` PASS: 0 errors, existing warnings remain
- `npm run build` PASS

## Fixture note

The test looks for `src-tauri/tests/fixtures/saves/Multiplayer_Slot_Aware/{before,after}` and skips when either fixture directory is absent.

The fixture ZIP is attached in this PR as [`Multiplayer_Slot_Aware_Garrick_Yuanti_to_Dwarf.zip`](https://github.com/user-attachments/files/26888067/Multiplayer_Slot_Aware_Garrick_Yuanti_to_Dwarf.zip) and was verified after upload by matching SHA-256:

`23f12885a06fddab99a54e80ae1085997f2e85a9245040b0ea9860c8630be041`

It contains:

- `before`: Garrick Ironheart in non-primary slot 1 as Yuan-ti Pureblood, class split barbarian/fighter, 7-level history
- `after`: Garrick Ironheart still in non-primary slot 1 as dwarf, fighter rebuild, 1-level history

The test copies only `Race`, `Subrace`, `ClassList`, `LvlStatList`, `FeatList`, and `SkillList` from `after` to `before`, then writes/re-parses the save and asserts:

- Garrick transition fields match the successful `after` fixture
- all other Garrick fields, including inventory/items/spells, stay unchanged
- primary `Mod_PlayerList` transition fields stay unchanged
- `player.bic` stays byte-for-byte unchanged
- `playerinfo.bin` stays byte-for-byte unchanged