### PR TITLE
[codex] Gate fixture-backed integration tests behind a feature

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -41,9 +41,9 @@ jobs:
         working-directory: ./src-tauri
         run: cargo clippy -- -D warnings
 
-      - name: run tests
+      - name: run default tests
         working-directory: ./src-tauri
-        run: cargo test --lib
+        run: cargo test
 
   build:
     needs: [check]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,10 +6,54 @@ authors = ["you"]
 license = ""
 repository = ""
 edition = "2024"
+autotests = false
 
 [lib]
 name = "app_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
+
+[features]
+integration-tests = []
+
+[[test]]
+name = "character"
+path = "tests/character.rs"
+required-features = ["integration-tests"]
+
+[[test]]
+name = "debugging"
+path = "tests/debugging.rs"
+required-features = ["integration-tests"]
+
+[[test]]
+name = "file_operations"
+path = "tests/file_operations.rs"
+required-features = ["integration-tests"]
+
+[[test]]
+name = "gamedata"
+path = "tests/gamedata.rs"
+required-features = ["integration-tests"]
+
+[[test]]
+name = "parsing"
+path = "tests/parsing.rs"
+required-features = ["integration-tests"]
+
+[[test]]
+name = "save_pipeline"
+path = "tests/save_pipeline.rs"
+required-features = ["integration-tests"]
+
+[[test]]
+name = "services"
+path = "tests/services.rs"
+required-features = ["integration-tests"]
+
+[[test]]
+name = "utils"
+path = "tests/utils.rs"
+required-features = ["integration-tests"]
 
 [build-dependencies]
 tauri-build = { version = "2.5.3", features = [] }
@@ -139,5 +183,3 @@ cast_possible_wrap = "allow"
 cast_precision_loss = "allow"
 cast_sign_loss = "allow"
 case_sensitive_file_extension_comparisons = "allow"
-
-

--- a/src-tauri/tests/README.md
+++ b/src-tauri/tests/README.md
@@ -6,30 +6,38 @@ This directory contains integration tests organized by domain.
 
 | Suite | Command | Purpose |
 |-------|---------|---------|
-| **character** | `cargo test --test character` | Character business logic (leveling, feats, skills, etc.) |
-| **parsing** | `cargo test --test parsing` | File format parsing (GFF, TLK, 2DA, ERF, XML) |
-| **gamedata** | `cargo test --test gamedata` | Game data inspection and validation |
-| **services** | `cargo test --test services` | Service layer (ResourceManager, SavegameHandler, etc.) |
-| **utils** | `cargo test --test utils` | Utility functions (zip, caching, path discovery) |
+| **character** | `cargo test --features integration-tests --test character` | Character business logic (leveling, feats, skills, etc.) |
+| **parsing** | `cargo test --features integration-tests --test parsing` | File format parsing (GFF, TLK, 2DA, ERF, XML) |
+| **gamedata** | `cargo test --features integration-tests --test gamedata` | Game data inspection and validation |
+| **services** | `cargo test --features integration-tests --test services` | Service layer (ResourceManager, SavegameHandler, etc.) |
+| **utils** | `cargo test --features integration-tests --test utils` | Utility functions (zip, caching, path discovery) |
+| **debugging** | `cargo test --features integration-tests --test debugging` | Local diagnostics for fixtures and binary format investigations |
+| **file_operations** | `cargo test --features integration-tests --test file_operations` | Save/path file operation coverage |
+| **save_pipeline** | `cargo test --features integration-tests --test save_pipeline` | End-to-end save parsing and write flow coverage |
 
 ## Running Tests
 
 ```bash
-# Run all tests
+# Run the default test suite on a clean checkout
 cargo test
 
+# Compile and run all integration tests (requires local fixture data)
+cargo test --features integration-tests
+
 # Run a specific suite
-cargo test --test character
+cargo test --features integration-tests --test character
 
 # Run a specific test file within a suite
-cargo test --test character classes
+cargo test --features integration-tests --test character classes
 
 # Run with output visible (for gamedata inspection tests)
-cargo test --test gamedata player -- --nocapture
+cargo test --features integration-tests --test gamedata player -- --nocapture
 
 # Run a single test by name
-cargo test --test character test_abilities_and_cascades
+cargo test --features integration-tests --test character test_abilities_and_cascades
 ```
+
+By default, the integration test targets are disabled on clean checkouts because they depend on local NWN2 data and fixture files under `tests/fixtures/`.
 
 ## Directory Structure
 
@@ -87,6 +95,10 @@ tests/
 │   ├── zip_content_reader.rs # Zip file reading
 │   └── zip_indexer.rs        # Zip archive indexing
 │
+├── debugging.rs              # Entry point
+├── file_operations.rs        # Entry point
+├── save_pipeline.rs          # Entry point
+│
 ├── common/                   # Shared test utilities
 │   └── mod.rs                # TestContext, fixtures helpers
 │
@@ -117,6 +129,7 @@ Utility function behavior. "Does path discovery find the NWN2 install?"
 1. Add your test function to the appropriate file in the subdirectory
 2. Use `super::super::common::create_test_context` for full context
 3. Use `super::super::common::load_test_gff` for fixture loading
+4. Run the target with `--features integration-tests`
 
 ```rust
 use super::super::common::create_test_context;


### PR DESCRIPTION
## Scope

This PR is independent from the multiplayer/path-detection stack.

## What changed

- disables automatic integration-test discovery in `src-tauri`
- registers the current integration test entrypoints behind an explicit `integration-tests` Cargo feature
- updates the integration test README to document the new default-vs-opt-in commands
- switches the shared CI check job from `cargo test --lib` to `cargo test`, so CI verifies the default clean-checkout test story

## Why

A plain `cargo test` on a clean checkout can trip fixture-backed integration suites that assume local NWN2 data plus files under `src-tauri/tests/fixtures/...`. Making those suites opt-in preserves them for local deep validation without making the default developer or CI path fail immediately.

## Impact

- `cargo test` works on a clean checkout
- fixture-backed integration suites remain available via `cargo test --features integration-tests ...`
- no production/runtime behavior change

## Validation

- `cargo fmt --check` PASS
- `cargo test` PASS: 365 passed; 1 ignored
- `cargo test --features integration-tests --tests --no-run` PASS
- `cargo clippy -- -D warnings` PASS

## Remaining gap

Actually running `cargo test --features integration-tests` still requires the missing fixture files and local NWN2 data/save fixtures. This PR makes that dependency explicit instead of letting the default test command depend on local-only files.